### PR TITLE
DLC/Non DLC shrines toggleable seperately

### DIFF
--- a/src/MapMarker.ts
+++ b/src/MapMarker.ts
@@ -156,6 +156,12 @@ export class MapMarkerDungeon extends MapMarkerGenericLocationMarker {
   }
 }
 
+export class MapMarkerDungeonDLC extends MapMarkerDungeon {
+  constructor(mb: MapBase, l: any) {
+    super(mb, l);
+  }
+}
+
 export class MapMarkerPlace extends MapMarkerGenericLocationMarker {
   private isVillage: boolean;
 

--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -76,6 +76,13 @@ const MARKER_COMPONENTS: {[type: string]: MarkerComponent} = Object.freeze({
     filterIcon: MapIcons.VILLAGE.options.iconUrl,
     filterLabel: 'Places',
    },
+  'DungeonDLC': {
+    cl: MapMarkers.MapMarkerDungeonDLC,
+    detailsComponent: 'AppMapDetailsDungeon',
+    enableUpdates: false,
+    filterIcon: MapIcons.DUNGEON_DLC.options.iconUrl,
+    filterLabel: 'DLC Shrines',
+  },
   'Tower': {
     cl: MapMarkers.MapMarkerTower,
     enableUpdates: false,

--- a/src/services/MapMgr.ts
+++ b/src/services/MapMgr.ts
@@ -75,7 +75,13 @@ export class MapMgr {
   async init() {
     await Promise.all([
       fetch('/game_files/map_summary/MainField/static.json').then(r => r.json())
-          .then((d) => this.infoMainField = Object.freeze(d)),
+          .then((d) => 
+            {
+              d.markers["DungeonDLC"] = d.markers["Dungeon"].filter((l: any) => parseInt(l.SaveFlag.replace('Location_Dungeon', ''), 10) >= 120);
+              d.markers["Dungeon"] = d.markers["Dungeon"].filter((l: any) => parseInt(l.SaveFlag.replace('Location_Dungeon', ''), 10) < 120);
+              console.log(d);
+              this.infoMainField = Object.freeze(d);
+            }),
     ]);
   }
 

--- a/src/services/MapMgr.ts
+++ b/src/services/MapMgr.ts
@@ -79,7 +79,6 @@ export class MapMgr {
             {
               d.markers["DungeonDLC"] = d.markers["Dungeon"].filter((l: any) => parseInt(l.SaveFlag.replace('Location_Dungeon', ''), 10) >= 120);
               d.markers["Dungeon"] = d.markers["Dungeon"].filter((l: any) => parseInt(l.SaveFlag.replace('Location_Dungeon', ''), 10) < 120);
-              console.log(d);
               this.infoMainField = Object.freeze(d);
             }),
     ]);


### PR DESCRIPTION
Make DLC/Non DLC shirnes independantly toggleable on the map. Useful to see only DLC or non DLC shrines