### PR TITLE
Added ability to show item drop tables for detail object display

### DIFF
--- a/src/components/AppMapDetailsObj.ts
+++ b/src/components/AppMapDetailsObj.ts
@@ -352,4 +352,33 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj|Map
     this.staticData.persistentAreaMarkers.forEach(m => m.remove());
     this.staticData.persistentAreaMarkers = [];
   }
+
+  getName(name: string) {
+    return MsgMgr.getInstance().getName(name) || name;
+  }
+  drop_table_format() : string {
+      if(!this.obj) {
+          return "";
+      }
+      if(!this.obj.drop_table) {
+          return "";
+      }
+      let lines = [];
+      let table_names = Object.keys(this.obj.drop_table);
+      for(var i = 0; i < table_names.length; i++) {
+          let table = this.obj.drop_table[table_names[i]];
+          let n = table.n;
+          if(n[0] == n[1]) {
+              lines.push(`<span style="text-decoration: underline;"><b>${table_names[i]}</b> - x${n[0]}</span>`);
+          } else {
+              lines.push(`<b>${table_names[i]}</b> - x${n[0]}-${n[1]}`);
+          }
+          let items = Object.keys(table.pop);
+          for(var j = 0; j < items.length; j++) {
+              lines.push(`  ${table.pop[items[j]].toFixed(0).padStart(4, ' ')}% - ${this.getName(items[j])}`);
+          }
+      }
+      return lines.join("\n");
+  }
+
 }

--- a/src/components/AppMapDetailsObj.ts
+++ b/src/components/AppMapDetailsObj.ts
@@ -356,7 +356,7 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj|Map
     this.staticData.persistentAreaMarkers = [];
   }
 
-  getName(name: string) {
+  static getName(name: string) {
     return MsgMgr.getInstance().getName(name) || name;
   }
 
@@ -364,7 +364,7 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj|Map
     return Object.keys(this.dropTables).length > 0;
   }
 
-  dropTableFormat() : string {
+  formatDropTable() : string {
     let lines = [];
     let names = Object.keys(this.dropTables);
     for(var i = 0; i < names.length; i++) {
@@ -382,6 +382,7 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj|Map
     }
     return lines.join("\n");
   }
+
   getDropTableName() {
     if(!this.obj || !this.obj.data || !this.obj.data['!Parameters']) {
       return "";
@@ -396,5 +397,4 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj|Map
     }
     return "Normal";
   }
-
 }

--- a/src/components/AppMapDetailsObj.ts
+++ b/src/components/AppMapDetailsObj.ts
@@ -83,6 +83,7 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj|Map
   private genGroup: ObjectData[] = [];
   private genGroupSet: Map<number, ObjectData> = new Map();
 
+  private dropTables: {[key: string]: any} = {};
   private links: PlacementLink[] = [];
   private linksToSelf: PlacementLink[] = [];
   private linkTagInputs: PlacementLink[] = [];
@@ -96,6 +97,7 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj|Map
     this.obj = null;
     this.genGroup = [];
     this.genGroupSet.clear();
+    this.dropTables = {};
     this.links = [];
     this.linksToSelf = [];
     this.linkTagInputs = [];
@@ -103,6 +105,7 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj|Map
     this.areaMarkers = [];
 
     this.obj = (await MapMgr.getInstance().getObjByObjId(this.minObj.objid))!;
+    this.dropTables = await MapMgr.getInstance().getObjDropTables(this.obj.data.UnitConfigName, this.getDropTableName());
     this.genGroup = await MapMgr.getInstance().getObjGenGroup(this.obj.map_type, this.obj.map_name, this.obj.hash_id);
     for (const obj of this.genGroup) {
       this.genGroupSet.set(obj.hash_id, obj);
@@ -356,29 +359,42 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj|Map
   getName(name: string) {
     return MsgMgr.getInstance().getName(name) || name;
   }
-  drop_table_format() : string {
-      if(!this.obj) {
-          return "";
+
+  dropTableExists() {
+    return Object.keys(this.dropTables).length > 0;
+  }
+
+  dropTableFormat() : string {
+    let lines = [];
+    let names = Object.keys(this.dropTables);
+    for(var i = 0; i < names.length; i++) {
+      let table = this.dropTables[ names[i] ];
+      let n = table.n;
+      if(n[0] == n[1]) {
+        lines.push(`<span style="text-decoration: underline;"><b>${names[i]}</b> - x${n[0]}</span>`);
+      } else {
+        lines.push(`<b>${names[i]}</b> - x${n[0]}-${n[1]}`);
       }
-      if(!this.obj.drop_table) {
-          return "";
+      let items = Object.keys(table.pop);
+      for(var j = 0; j < items.length; j++) {
+        lines.push(`  ${table.pop[items[j]].toFixed(0).padStart(4, ' ')}% - ${this.getName(items[j])}`);
       }
-      let lines = [];
-      let table_names = Object.keys(this.obj.drop_table);
-      for(var i = 0; i < table_names.length; i++) {
-          let table = this.obj.drop_table[table_names[i]];
-          let n = table.n;
-          if(n[0] == n[1]) {
-              lines.push(`<span style="text-decoration: underline;"><b>${table_names[i]}</b> - x${n[0]}</span>`);
-          } else {
-              lines.push(`<b>${table_names[i]}</b> - x${n[0]}-${n[1]}`);
-          }
-          let items = Object.keys(table.pop);
-          for(var j = 0; j < items.length; j++) {
-              lines.push(`  ${table.pop[items[j]].toFixed(0).padStart(4, ' ')}% - ${this.getName(items[j])}`);
-          }
+    }
+    return lines.join("\n");
+  }
+  getDropTableName() {
+    if(!this.obj || !this.obj.data || !this.obj.data['!Parameters']) {
+      return "";
+    }
+    const params : {[key:string]: any} = this.obj.data['!Parameters'];
+    let dropTableName = "Normal";
+    let keys = ['ArrowName', 'DropTable'];
+    for(var i = 0; i < keys.length; i++) {
+      if(keys[i] in params) {
+        return params[keys[i]];
       }
-      return lines.join("\n");
+    }
+    return "Normal";
   }
 
 }

--- a/src/components/AppMapDetailsObj.ts
+++ b/src/components/AppMapDetailsObj.ts
@@ -369,15 +369,15 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj|Map
     let names = Object.keys(this.dropTables);
     for(var i = 0; i < names.length; i++) {
       let table = this.dropTables[ names[i] ];
-      let n = table.n;
-      if(n[0] == n[1]) {
-        lines.push(`<span style="text-decoration: underline;"><b>${names[i]}</b> - x${n[0]}</span>`);
+      let repeatNum = table.repeat_num;
+      if(repeatNum[0] == repeatNum[1]) {
+        lines.push(`<span style="text-decoration: underline;"><b>${names[i]}</b> - x${repeatNum[0]}</span>`);
       } else {
-        lines.push(`<b>${names[i]}</b> - x${n[0]}-${n[1]}`);
+        lines.push(`<span style="text-decoration: underline;"><b>${names[i]}</b> - x${repeatNum[0]}-${repeatNum[1]}</span>`);
       }
-      let items = Object.keys(table.pop);
+      let items = Object.keys(table.items).sort(function(a,b) {return table.items[b]-table.items[a];});
       for(var j = 0; j < items.length; j++) {
-        lines.push(`  ${table.pop[items[j]].toFixed(0).padStart(4, ' ')}% - ${this.getName(items[j])}`);
+        lines.push(`  ${table.items[items[j]].toFixed(1).padStart(4, ' ')}% - ${this.getName(items[j])}`);
       }
     }
     return lines.join("\n");

--- a/src/components/AppMapDetailsObj.vue
+++ b/src/components/AppMapDetailsObj.vue
@@ -66,7 +66,7 @@
 
       <section v-if="dropTableExists()">
         <h4 class="subsection-heading">Drop Table</h4>
-        <pre class="obj-params" v-html=" dropTableFormat()"></pre>
+        <pre class="obj-params" v-html="formatDropTable()"></pre>
       </section>
     </section>
 

--- a/src/components/AppMapDetailsObj.vue
+++ b/src/components/AppMapDetailsObj.vue
@@ -63,6 +63,11 @@
         <h4 class="subsection-heading">Parameters</h4>
         <pre class="obj-params">{{JSON.stringify(obj.data['!Parameters'], undefined, 2)}}</pre>
       </section>
+
+      <section v-if="obj.drop_table">
+        <h4 class="subsection-heading">Drop Table</h4>
+        <pre class="obj-params" v-html=" drop_table_format()"></pre>
+      </section>
     </section>
 
     <section v-if="isSearchResult()">

--- a/src/components/AppMapDetailsObj.vue
+++ b/src/components/AppMapDetailsObj.vue
@@ -64,9 +64,9 @@
         <pre class="obj-params">{{JSON.stringify(obj.data['!Parameters'], undefined, 2)}}</pre>
       </section>
 
-      <section v-if="obj.drop_table">
+      <section v-if="dropTableExists()">
         <h4 class="subsection-heading">Drop Table</h4>
-        <pre class="obj-params" v-html=" drop_table_format()"></pre>
+        <pre class="obj-params" v-html=" dropTableFormat()"></pre>
       </section>
     </section>
 

--- a/src/services/MapMgr.ts
+++ b/src/services/MapMgr.ts
@@ -42,6 +42,9 @@ export interface ObjectMinData {
   // Only for weapons and enemies.
   scale?: number;
   sharp_weapon_judge_type?: number;
+
+  readonly drop_table?: {[key:string]: any};
+  readonly drop_tables?: {[key:string]: any};
 }
 
 export interface ObjectData extends ObjectMinData {

--- a/src/services/MapMgr.ts
+++ b/src/services/MapMgr.ts
@@ -42,9 +42,6 @@ export interface ObjectMinData {
   // Only for weapons and enemies.
   scale?: number;
   sharp_weapon_judge_type?: number;
-
-  readonly drop_table?: {[key:string]: any};
-  readonly drop_tables?: {[key:string]: any};
 }
 
 export interface ObjectData extends ObjectMinData {
@@ -104,6 +101,10 @@ export class MapMgr {
 
   getObjGenGroup(mapType: string, mapName: string, hashId: number): Promise<ObjectData[]> {
     return fetch(`${RADAR_URL}/obj/${mapType}/${mapName}/${hashId}/gen_group`).then(parse);
+  }
+
+  getObjDropTables(unitConfigName: string, tableName: string) {
+    return fetch(`${RADAR_URL}/drop/${unitConfigName}/${tableName}`).then(parse);
   }
 
   getObjs(mapType: string, mapName: string, query: string, withMapNames = false, limit = -1): Promise<ObjectMinData[]> {


### PR DESCRIPTION
If the `drop_table` value exists in the returned object from the radar server, it formats the drop table in a `pre` tag with some minor formatting.  Format should be similar to the original raw text.

Nothing is currently done with `drop_tables`.  It would allow a bit of customization if the Actor can be `iced` or `burned` or `happyed`, ...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/29)
<!-- Reviewable:end -->
