### PR TITLE
Add Tooltip and Popups for markers/lines

### DIFF
--- a/src/components/AppMapPopup.ts
+++ b/src/components/AppMapPopup.ts
@@ -1,0 +1,20 @@
+
+import Vue from 'vue';
+import Component from 'vue-class-component';
+
+@Component({
+    props: {
+        title: String,
+        text: String,
+    },
+    watch: {
+        title: function(new_val: string, old_val: string) {
+            this.$emit('title', new_val);
+        },
+        text: function(new_val: string, old_val: string) {
+            this.$emit('text', new_val);
+        }
+    },
+})
+
+export default class AppMapPopup extends Vue { }

--- a/src/components/AppMapPopup.vue
+++ b/src/components/AppMapPopup.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <input class="w-100" placeholder="Title ..." v-model="title">
+    <textarea class="w-100" placeholder="Description ..." v-model="text"></textarea>
+  </div>
+</template>
+
+<style lang="less">
+  textarea {
+    min-height: 75px;
+  }
+</style>
+<script src="./AppMapPopup.ts"></script>


### PR DESCRIPTION
Adds Popups to edit descriptions of Markers and Polylines as referenced in #19 
Add Tooltips taken from the `title` value.

This add an AppMapPopup.vue with associated Typescript file.  This vue emits messages `title` and `text` when the values are changed to keep the GeoJSON in sync.

If the Marker structure includes `feature.properties` it will save these values to the exported file, see https://stackoverflow.com/a/35819611

I am open to improvements to the popup's style or keeping the GeoJSON `properties` in sync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/31)
<!-- Reviewable:end -->
