### PR TITLE
Fix color on import/export. Fix highlight polyline and contextmenu.

### DIFF
--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -358,8 +358,8 @@ export default class AppMap extends mixins(MixinUtil) {
     this.sidebar.open(pane);
   }
 
-  private initGeojsonFeature(layer: L.Layer) {
-    if (!(layer instanceof L.Path))
+  private initGeojsonFeature(layer: any) {
+    if (!(layer.setStyle))
       return;
 
     layer.on('mouseover', () => {
@@ -368,6 +368,9 @@ export default class AppMap extends mixins(MixinUtil) {
     layer.on('mouseout', () => {
       layer.setStyle({ weight: 3 });
     });
+    if (!layer.bindContextMenu) {
+      return;
+    }
     // @ts-ignore
     layer.bindContextMenu({
       contextmenu: true,
@@ -431,6 +434,10 @@ export default class AppMap extends mixins(MixinUtil) {
     data.features.forEach((feat: any) => {
       // Create Layer
       let layer: any = L.GeoJSON.geometryToLayer(feat);
+      // Only set style for Polylines not Markers
+      if (layer.setStyle) {
+        layer.setStyle({ color: feat.style.color || this.drawLineColor });
+      }
       // Create Feature.Properties on Layer
       addGeoJSONFeatureToLayer(layer);
       // Copy Properties from GeoJSON

--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -436,7 +436,11 @@ export default class AppMap extends mixins(MixinUtil) {
       let layer: any = L.GeoJSON.geometryToLayer(feat);
       // Only set style for Polylines not Markers
       if (layer.setStyle) {
-        layer.setStyle({ color: feat.style.color || this.drawLineColor });
+        let color = this.drawLineColor;
+        if (feat.style && feat.style.color) {
+          color = feat.style.color;
+        }
+        layer.setStyle({ color: color });
       }
       // Create Feature.Properties on Layer
       addGeoJSONFeatureToLayer(layer);


### PR DESCRIPTION
Colors are fixed for imports and exports. Needed to set the style directly after the layer was created, but only for Polylines, not Markers.

The change from `addData()` to `geometryToLayer()` (in previous commit) broke `initGeojsonFeature()` as it expected an L.Path, but the imported GeoJSON data returns a LayerGroup/FeatureGroup not a Path. The argument to initGeojsonFeature() now "any" and checks if the functions are available before attempting to call them (`setStyle` and `bindContextMenu`).

Tested importing and exporting data with and without colors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/32)
<!-- Reviewable:end -->
