### PR TITLE
Fix "Show all objects in map unit" for AocField

### DIFF
--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -733,8 +733,9 @@ export default class AppMap extends mixins(MixinUtil) {
 
   initContextMenu() {
     this.map.m.on(SHOW_ALL_OBJS_FOR_MAP_UNIT_EVENT, (e) => {
-      if (Settings.getInstance().mapType !== 'MainField' && Settings.getInstance().mapType !== 'AocField') {
-        this.searchAddGroup(`map:"${Settings.getInstance().mapType}/${Settings.getInstance().mapName}"`);
+      let mapType = Settings.getInstance().mapType;
+      if (mapType !== 'MainField' && mapType !== 'AocField') {
+        this.searchAddGroup(`map:"${mapType}/${Settings.getInstance().mapName}"`);
         return;
       }
 
@@ -743,7 +744,7 @@ export default class AppMap extends mixins(MixinUtil) {
       const xz = this.map.toXZ(latlng);
       if (!map.isValidPoint(xz))
         return;
-      this.searchAddGroup(`map:"MainField/${map.pointToMapUnit(xz)}"`);
+      this.searchAddGroup(`map:"${mapType}/${map.pointToMapUnit(xz)}"`);
     });
   }
 


### PR DESCRIPTION
Steps to reproduce:
- Set Map to AocField (Trial of the Sword)
- Show all objects in map unit

Expected:
    Units for Trial of the Sword appear
Actual:
   Nothing show up

Reported in BotW Speerunning Discord channel: trial-of the sword (on 8/20/2021) by Jhent. 

Message link: https://discord.com/channels/269611402854006785/419600864924139521/878322870898552862

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/36)
<!-- Reviewable:end -->
