### PR TITLE
Lotm doc

### DIFF
--- a/src/components/AppMap.vue
+++ b/src/components/AppMap.vue
@@ -67,7 +67,7 @@
           <code>fieldarea</code>: Field Map area (0 - 93)<br>
           <code>lotm</code>: Spawns with Lord of the Mountain (1 or 0)<br>
         </p>
-        <p>For more information on the last 4 columns, please read <a href="https://zeldamods.org/wiki/Difficulty_scaling">the article on <i>difficulty scaling</i></a>.</p>
+        <p>For more information on columns <code>hard</code>, <code>no_rankup</code>, <code>scale</code> and <code>bonus</code>, please read <a href="https://zeldamods.org/wiki/Difficulty_scaling">the article on <i>difficulty scaling</i></a>.</p>
 
         <h4 class="subsection-heading">Boolean operators</h4>
         <p>

--- a/src/components/AppMap.vue
+++ b/src/components/AppMap.vue
@@ -64,6 +64,8 @@
           <code>scale</code>: Will scale up (1 or 0)<br>
           <code>bonus</code>: Minimum bonus modifier tier (0, 1, 2 or 3)<br>
           <code>region</code>: Tower region name (e.g. Tabantha, Lanayru, Hateno) <br>
+          <code>fieldarea</code>: Field Map area (0 - 93)<br>
+          <code>lotm</code>: Spawns with Lord of the Mountain (1 or 0)<br>
         </p>
         <p>For more information on the last 4 columns, please read <a href="https://zeldamods.org/wiki/Difficulty_scaling">the article on <i>difficulty scaling</i></a>.</p>
 


### PR DESCRIPTION
Forgot to add the documentation to the help section for `fieldarea:` and `lotm:`.

Additions of new columns (at the bottom of the documentation list) required the note about difficulty scaling to be changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/41)
<!-- Reviewable:end -->
