### PR TITLE
Identify Actors on Eventide as not scaled

### DIFF
--- a/src/components/ObjectInfo.vue
+++ b/src/components/ObjectInfo.vue
@@ -29,6 +29,10 @@
       <i class="fas fa-fw fa-horse" style="text-shadow: lightblue 0px 0px 5px; color: lightblue;"></i>
       Lord of the Mountain
     </section>
+    <section class="search-result-rankup" v-if="data.field_area == 28">
+      <i class="fas fa-fw fa-ban" style="color:tomato"></i>
+      No rankup on Eventide Island
+    </section>
     <section class="search-result-bonus" v-if="data.sharp_weapon_judge_type > 0">
       <span v-if="data.sharp_weapon_judge_type == 1"><i class="far fa-star fa-fw" style="color: deepskyblue"></i> Minimum modifier tier: Blue (random)</span>
       <span v-if="data.sharp_weapon_judge_type == 2"><i class="fas fa-star fa-fw" style="color: deepskyblue"></i> Minimum modifier tier: Blue</span>


### PR DESCRIPTION
Indicate Actors on Eventide Island (`fieldarea: 28`) are not scaled by Ecosystem::LevelSensor

Should close #2 
