### PR TITLE
Add path length to tooltip and popup, saved on data export

### DIFF
--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -131,8 +131,10 @@ class LayerProps {
     this.pathLength = 0;
   }
   lengthAsString(): string {
+    if (this.pathLength <= 0.0) {
+      return "";
+    }
     return `${this.pathLength.toFixed(2)} m`;
-
   }
   tooltip(): string {
     return (this.title || 'Unnamed') + " " + this.lengthAsString();

--- a/src/components/AppMapPopup.ts
+++ b/src/components/AppMapPopup.ts
@@ -6,6 +6,7 @@ import Component from 'vue-class-component';
   props: {
     title: String,
     text: String,
+    pathLength: Number,
   },
   watch: {
     title: function(new_val: string, old_val: string) {

--- a/src/components/AppMapPopup.vue
+++ b/src/components/AppMapPopup.vue
@@ -2,6 +2,9 @@
   <div>
     <input class="w-100" placeholder="Title ..." v-model="title">
     <textarea class="w-100" placeholder="Description ..." v-model="text"></textarea>
+    <div v-if="pathLength > 0">
+      Length: {{pathLength.toFixed(2)}}
+    </div>
   </div>
 </template>
 

--- a/src/util/polyline.ts
+++ b/src/util/polyline.ts
@@ -1,0 +1,45 @@
+import * as L from 'leaflet';
+
+
+function pointDist(a: L.LatLng, b: L.LatLng): number {
+  let dx = a.lng - b.lng;
+  let dy = a.lat - b.lat;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+function pointArrayLength(p: L.LatLng[] | L.LatLng[][] | L.LatLng[][][]): number {
+  let dist = 0.0;
+  if (p.length == 0) {
+    return dist;
+  }
+  if (p[0] instanceof L.LatLng) {
+    for (let i = 1; i < p.length; i++) {
+      dist += pointDist(p[i - 1] as L.LatLng, p[i] as L.LatLng);
+    }
+    return dist;
+  }
+  for (let i = 0; i < p.length; i++) {
+    dist += pointArrayLength(p[i] as L.LatLng[] | L.LatLng[][]);
+  }
+  return dist;
+}
+
+function polyLineLength(layer: L.Polyline) {
+  return pointArrayLength(layer.getLatLngs());
+}
+
+export function calcLayerLength(layer: L.Marker | L.Polyline) {
+  if (!layer.feature) {
+    return;
+  }
+  if (layer instanceof L.Polyline) {
+    layer.feature.properties.pathLength = polyLineLength(layer);
+  } else {
+    layer.feature.properties.length = 0;
+  }
+  // Tell Popup the length parameter
+  let z: any = layer;
+  if (z.popup) {
+    z.popup.pathLength = layer.feature.properties.pathLength;
+  }
+}


### PR DESCRIPTION
Add pathLength value to tooltip and popups. Path length is saved on data export. 

I stored the `popup` instance in the `L.Polyline | L.Marker` as it is needed to keep the `pathLength` synced in the `popup`. 

**Request**
Responding to  https://discord.com/channels/269611402854006785/360564354979987458/885657189736415293
> Would it be possible to implement a total amount of distance for all lines drawn on the object map? It'd be a simple way to compare a few branches at once without needing to pull up a calculator

**Test**
I checked this by loading the 100% route json file, exporting that, then reloading the new json file.  The exported json ata has the `pathLength` included within the Feature Properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/43)
<!-- Reviewable:end -->
