### PR TITLE
Suppress extra messages to the console

### DIFF
--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -8,6 +8,9 @@ import 'leaflet-sidebar-v2/css/leaflet-sidebar.css';
 import 'leaflet-draw';
 import 'leaflet-draw/dist/leaflet.draw.css';
 
+import VueRouter from 'vue-router'
+const { isNavigationFailure, NavigationFailureType } = VueRouter
+
 import debounce from 'lodash/debounce';
 import Vue from 'vue';
 import Component, { mixins } from 'vue-class-component';
@@ -285,6 +288,10 @@ export default class AppMap extends mixins(MixinUtil) {
         zoom: this.map.m.getZoom(),
       },
       query: this.$route.query,
+    }).catch(err => {
+      if (!isNavigationFailure(err, NavigationFailureType.duplicated)) {
+        console.log(err);
+      }
     });
     this.updatingRoute = false;
   }

--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -8,8 +8,8 @@ import 'leaflet-sidebar-v2/css/leaflet-sidebar.css';
 import 'leaflet-draw';
 import 'leaflet-draw/dist/leaflet.draw.css';
 
-import VueRouter from 'vue-router'
-const { isNavigationFailure, NavigationFailureType } = VueRouter
+import VueRouter from 'vue-router';
+const { isNavigationFailure, NavigationFailureType } = VueRouter;
 
 import debounce from 'lodash/debounce';
 import Vue from 'vue';
@@ -290,7 +290,7 @@ export default class AppMap extends mixins(MixinUtil) {
       query: this.$route.query,
     }).catch(err => {
       if (!isNavigationFailure(err, NavigationFailureType.duplicated)) {
-        console.log(err);
+        console.error(err);
       }
     });
     this.updatingRoute = false;

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -47,7 +47,6 @@ export class Settings {
     window.addEventListener('beforeunload', (event) => {
       this.save();
     });
-    console.log('Settings initialised', this);
   }
 
   private load() {


### PR DESCRIPTION
1. Remove code that output:

> Settings initialised Object { beforeSaveCallbacks ....

2. Add a check to skip printing the following message to the console:

>Uncaught (in promise) NavigationDuplicated: Avoided redundant navigation to current location: "/map/z3,0,0".
      createRouterError vue-router.esm.js:2065
      createNavigationDuplicatedError vue-router.esm.js:2035
      confirmTransition vue-router.esm.js:2328
      transitionTo vue-router.esm.js:2260
      replace vue-router.esm.js:2726
      replace vue-router.esm.js:3039
      replace vue-router.esm.js:3038
      updateRoute AppMap.ts:280
      initMapRouteIntegration AppMap.ts:298
      mounted AppMap.ts:972
      VueJS 11
      initUi main.ts:40
      main main.ts:19
      async* main.ts:46
      ts app.js:7485
      __webpack_require__ app.js:790
      fn app.js:101
      1 app.js:7643
      __webpack_require__ app.js:790
      <anonymous> app.js:857
      <anonymous> app.js:860
  vue-router.esm.js:2065

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/53)
<!-- Reviewable:end -->
