### PR TITLE
Now display auto items (Fish, Birds, Insects, ...)

### DIFF
--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -248,9 +248,11 @@ export default class AppMap extends mixins(MixinUtil) {
 
   private areaMapLayer = new ui.Unobservable(L.layerGroup());
   private areaMapLayersByData: ui.Unobservable<Map<any, L.Layer[]>> = new ui.Unobservable(new Map());
+  private areaAutoItem = new ui.Unobservable(L.layerGroup());
   shownAreaMap = '';
   areaWhitelist = '';
   showKorokIDs = false;
+  shownAutoItem = '';
 
   private mapUnitGrid = new ui.Unobservable(L.layerGroup());
   showMapUnitGrid = false;
@@ -886,6 +888,20 @@ export default class AppMap extends mixins(MixinUtil) {
   initAreaMap() {
     this.areaMapLayer.data.addTo(this.map.m);
   }
+  initAutoItem() {
+    this.areaAutoItem.data.addTo(this.map.m);
+  }
+
+  async loadAutoItem(name: string) {
+    this.areaAutoItem.data.clearLayers();
+    if (!name)
+      return;
+    const areas = await MapMgr.getInstance().fetchAreaMap(name);
+    let layers: L.Path[] = ui.areaMapToLayers(areas);
+    layers.forEach(l => this.areaAutoItem.data.addLayer(l));
+    this.areaAutoItem.data.setZIndex(1000);
+  }
+
 
   async loadAreaMap(name: string) {
     this.areaMapLayer.data.clearLayers();
@@ -936,6 +952,10 @@ export default class AppMap extends mixins(MixinUtil) {
   onShownAreaMapChanged() {
     this.$nextTick(() => this.loadAreaMap(this.shownAreaMap));
   }
+  onShownAutoItemChanged() {
+    this.$nextTick(() => this.loadAutoItem(this.shownAutoItem));
+  }
+
   async initMapSafeAreas() {
     const areas = await MapMgr.getInstance().fetchAreaMap("AutoSafe");
     let layers: L.Path[] = ui.areaMapToLayers(areas);
@@ -996,6 +1016,7 @@ export default class AppMap extends mixins(MixinUtil) {
     this.initMapRouteIntegration();
     this.initMarkers();
     this.initAreaMap();
+    this.initAutoItem();
     this.initMapUnitGrid();
     this.initSidebar();
     this.initDrawTools();

--- a/src/components/AppMap.vue
+++ b/src/components/AppMap.vue
@@ -155,6 +155,17 @@
         </b-form-group>
         <b-checkbox switch v-model="showSafeAreas" @change="onShowSafeAreas">Enemy Non-Search Areas (Safe Zones)</b-checkbox>
         <b-checkbox switch v-model="showMapUnitGrid" @change="onShowMapUnitGridChanged">Show map unit grid</b-checkbox>
+        <hr/>
+        <h4 class="subsection-heading">Item Auto Placement</h4>
+        <b-radio-group stacked class="mb-4" v-model="shownAutoItem" @change="onShownAutoItemChanged">
+          <b-radio value="">None</b-radio>
+          <b-radio value="AutoFish">Auto Fish</b-radio>
+          <b-radio value="AutoBird">Auto Bird</b-radio>
+          <b-radio value="AutoInsect">Auto Insect</b-radio>
+          <b-radio value="AutoAnimal">Auto Animal</b-radio>
+          <b-radio value="AutoEnemy">Auto Enemy</b-radio>
+          <b-radio value="AutoMaterial">Auto Material</b-radio>
+        </b-radio-group>
       </div>
 
       <div class="leaflet-sidebar-pane" id="spane-draw">

--- a/src/util/ui.ts
+++ b/src/util/ui.ts
@@ -58,9 +58,19 @@ export function shadeColor(color: string, percent: number) {
   return '#' + (0x1000000 + (R < 255 ? R < 1 ? 0 : R : 255) * 0x10000 + (G < 255 ? G < 1 ? 0 : G : 255) * 0x100 + (B < 255 ? B < 1 ? 0 : B : 255)).toString(16).slice(1);
 }
 
+function areaTooltip(area: any): string {
+  let auto_areas = ['Fish', 'Bird', 'Insect', 'Animal', 'Enemy', 'Material'];
+  if (area.type == "Safe") {
+    return "Safe Area";
+  } else if (auto_areas.includes(area.type)) {
+    let parts = area.items.map((item: any) => `- ${item.real_name}: ${item.num}`).join("<br/>");
+    return [`Auto ${area.type}`, parts, `<small>Field Map Area ${area.field_map_area}</small>`].join("<br/>");
+  }
+  return 'Area';
+}
+
 export function areaMapToLayers(areas: any): L.Path[] {
   const nentries = Object.entries(areas).length;
-  const keys = Object.keys(areas);
   let layers: L.Path[] = Object.values(areas).map((feature: any, i) => {
     let layer: L.Circle | L.Polygon = toShape(feature.shape, feature.loc, feature.scale, feature.rotate);
     let color = feature.color || genColor(nentries, i);
@@ -71,15 +81,15 @@ export function areaMapToLayers(areas: any): L.Path[] {
       // @ts-ignore
       contextmenu: true,
     });
-    layerHover(layer, keys[i]);
+    layerHover(layer, areaTooltip(feature));
     return layer;
   });
   return layers;
 }
 
 
-export function layerHover(layer: L.Path, data: any) {
-  layer.bindTooltip('Area ' + data.toString());
+export function layerHover(layer: L.Path, data: string) {
+  layer.bindTooltip(data);
   layer.on('mouseover', () => {
     layer.setStyle({ weight: 4, fillOpacity: 0.3 });
   });


### PR DESCRIPTION
Adds a section to the Filter pane containing `Item Auto Placement` for Fish, Birds, Insects, Animals, Enemies, and Materials.  

Uses the Auto*.json files from the `radar` repo. (They should placed be in `game_files/ecosystem` along side the `SafeZones.json` file)

The shape's color and tooltip text are coded into the json files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/57)
<!-- Reviewable:end -->
