### PR TITLE
Add color to polygons, rectangles, circles, and markers

### DIFF
--- a/src/components/AppMap.vue
+++ b/src/components/AppMap.vue
@@ -173,7 +173,7 @@
         <b-btn size="sm" block variant="primary" @click="toggleDraw()"><i class="fa fa-draw-polygon"></i> Toggle draw controls</b-btn>
         <hr>
         <h4 class="subsection-heading">Polyline color</h4>
-        <input type="color" v-model="drawLineColor" @change="drawOnColorChange"> <b-btn size="sm" variant="link" @click="drawLineColor = '#3388ff'">Reset to default</b-btn>
+        <input type="color"  @input="drawOnColorChange" value="#3388ff"> <b-btn size="sm" variant="link" @click="drawLineColor = '#3388ff'">Reset to default</b-btn>
         <hr>
         <h4 class="subsection-heading">Data import/export</h4>
         <p>Exported data includes search groups and drawn objects.</p>

--- a/src/util/ui.ts
+++ b/src/util/ui.ts
@@ -168,3 +168,31 @@ export function toShape(shape: string, loc: number[], scale: number[], rotate: n
   }
   return circle(loc, scale, rotate);
 }
+
+
+export function svgIcon(fill: string): L.DivIcon {
+  let stroke: string = shadeColor(fill, -10) as string;
+  // Note: Attach styles directly to paths, as styles within <style></style> are overwritten by new SVG Icons
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="30" height="40" viewBox="0 0 50.29 81.47">
+    <defs>
+      <linearGradient id="linear-gradient" x1="281.94" y1="307.83" x2="281.94" y2="383.66" gradientUnits="userSpaceOnUse">
+        <stop offset="0" stop-color="#fff" stop-opacity="0.2"/>
+        <stop offset="1" stop-color="#fff" stop-opacity="0.0"/>
+      </linearGradient>
+    </defs>
+    <g id="bg"><path fill="${fill}" d="M282.11,383.48s19.55-37,21-41.5c14.34-45.08-56.28-44.9-42.58-.1C262.09,347.07,282.11,383.48,282.11,383.48Z" transform="translate(-256.73 -306.23)"/></g>
+    <g id="grad"><path fill="url(#linear-gradient)" d="M282.11,383.48s19.55-37,21-41.5c14.34-45.08-56.28-44.9-42.58-.1C262.09,347.07,282.11,383.48,282.11,383.48Z" transform="translate(-256.73 -306.23)"/></g>
+    <g id="outWhiteBorder"><path stroke-miterlimit="10" fill="none" stroke="#fff" stroke-opacity="0.15" stroke-width="5px" d="M282.11,383.48s19.55-37,21-41.5c14.34-45.08-56.28-44.9-42.58-.1C262.09,347.07,282.11,383.48,282.11,383.48Z" transform="translate(-256.73 -306.23)"/></g>
+    <g id="outBorder"><path fill="none" stroke-miterlimit="10" stroke="${stroke}" stroke-width="2px" d="M282.11,383.48s19.55-37,21-41.5c14.34-45.08-56.28-44.9-42.58-.1C262.09,347.07,282.11,383.48,282.11,383.48Z" transform="translate(-256.73 -306.23)"/></g>
+    <g id="inWhiteBorder"><circle class="cls-3" cx="25.27" cy="24.83" r="9.15"/></g>
+    <g id="inBorder"><circle fill="#fff" stroke="${stroke}" stroke-width="2px" cx="25.27" cy="24.83" r="9.15"/></g>
+  </svg>
+`;
+  const svgIcon = L.divIcon({
+    html: svg,
+    className: "",
+    iconSize: [40, 40],
+    iconAnchor: [12, 40],
+  });
+  return svgIcon;
+}


### PR DESCRIPTION
Adds the ability to change colors for 
 - Polygons
 - Rectangles
 - Circles
 - Markers

Markers are now all `L.divIcon` created using an SVG. The markers should be close to the previous png markers used by Leaflet.  

The `v-model` was removed from `<input type="color">` as it was laggy.  Should
resolve #54

To avoid unnecessary calculation, changes in color are hidden behind a `debounce`. 
These changes allow color modification without closing the color picker window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/58)
<!-- Reviewable:end -->
