### PR TITLE
Display line lengths for only polylines, not polygons or rectangles

### DIFF
--- a/src/util/polyline.ts
+++ b/src/util/polyline.ts
@@ -1,5 +1,5 @@
 import * as L from 'leaflet';
-
+import * as ui from '@/util/ui';
 
 function pointDist(a: L.LatLng, b: L.LatLng): number {
   let dx = a.lng - b.lng;
@@ -32,8 +32,9 @@ export function calcLayerLength(layer: L.Marker | L.Polyline) {
   if (!layer.feature) {
     return;
   }
-  if (layer instanceof L.Polyline) {
-    layer.feature.properties.pathLength = polyLineLength(layer);
+  layer.feature.properties.pathLength = 0;
+  if (ui.leafletType(layer) == ui.LeafletType.Polyline) {
+    layer.feature.properties.pathLength = polyLineLength(layer as L.Polyline);
   } else {
     layer.feature.properties.length = 0;
   }

--- a/src/util/ui.ts
+++ b/src/util/ui.ts
@@ -196,3 +196,35 @@ export function svgIcon(fill: string): L.DivIcon {
   });
   return svgIcon;
 }
+
+export enum LeafletType {
+  Rectangle,
+  Polygon,
+  Polyline,
+  Circle,
+  CircleMarker,
+  Marker,
+  Path,
+  Layer,
+}
+
+// https://leafletjs.com/examples/extending/class-diagram.html
+// https://stackoverflow.com/a/56987060
+export function leafletType(layer: L.Layer): LeafletType {
+  if (layer instanceof L.Rectangle) {
+    return LeafletType.Rectangle;
+  } else if (layer instanceof L.Polygon) {
+    return LeafletType.Polygon;
+  } else if (layer instanceof L.Polyline) {
+    return LeafletType.Polyline;
+  } else if (layer instanceof L.Circle) {
+    return LeafletType.Circle;
+  } else if (layer instanceof L.CircleMarker) {
+    return LeafletType.CircleMarker;
+  } else if (layer instanceof L.Marker) {
+    return LeafletType.Marker;
+  } else if (layer instanceof L.Path) {
+    return LeafletType.Path;
+  }
+  return LeafletType.Layer;
+}


### PR DESCRIPTION
Adds a check for computing line lengths only for `L.Polyline`, but not `L.Polygon` or `L.Rectangle`

`L.Polygon` and `L.Rectangle` are derived(?) from `L.Polyline` as diagrammed below:
https://leafletjs.com/examples/extending/class-diagram.html

So checking for an `instanceof L.Polyline` returns `true` for `L.Polygons` and `L.Rectangles`.  The `leafletType()` function checks first for `L.Rectangle` and `L.Polygon`, then `L.Polyline`. See https://stackoverflow.com/a/56987060

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/59)
<!-- Reviewable:end -->
