### PR TITLE
Positions are now [x,y,z] (y-added) where x:E-W z:S-N y:Up-Down

### DIFF
--- a/src/MapBase.ts
+++ b/src/MapBase.ts
@@ -26,17 +26,17 @@ export class MapBase {
   zoom: number = map.DEFAULT_ZOOM;
   private zoomChangeCbs: Array<(zoom: number) => void> = [];
 
-  toXZ(latlng: L.LatLng): Point {
+  toXYZ(latlng: L.LatLng): Point {
     return [latlng.lng, 0, latlng.lat];
   }
-  fromXZ(pos: Point): L.LatLngExpression {
+  fromXYZ(pos: Point): L.LatLngExpression {
     return [pos[2], pos[0]];
   }
 
   setView(pos: Point, zoom = -1) {
     this.center = pos;
     this.setZoomProp(zoom == -1 ? this.m.getZoom() : zoom);
-    this.m.setView(this.fromXZ(this.center), this.zoom);
+    this.m.setView(this.fromXYZ(this.center), this.zoom);
   }
 
   emitMarkerSelectedEvent(marker: any) { this.m.fireEvent(MARKER_SELECTED_EVENT, { marker }); }
@@ -105,7 +105,7 @@ export class MapBase {
         {
           text: 'Copy coordinates',
           callback: ({ latlng }: ui.LeafletContextMenuCbArg) => {
-            const [x, y, z] = this.toXZ(latlng);
+            const [x, y, z] = this.toXYZ(latlng);
             ui.copyToClipboard(`${x},${z}`);
           },
         },
@@ -131,7 +131,7 @@ export class MapBase {
       this.setZoomProp(evt.zoom);
     });
     this.registerMoveEndCb(() => {
-      this.center = this.toXZ(this.m.getCenter());
+      this.center = this.toXYZ(this.m.getCenter());
     });
   }
 

--- a/src/MapBase.ts
+++ b/src/MapBase.ts
@@ -22,15 +22,15 @@ export const MARKER_SELECTED_EVENT = 'objmap::markerSelected';
 export class MapBase {
   m!: L.Map;
   private rc!: L.RasterCoords;
-  center: Point = [0, 0];
+  center: Point = [0, 0, 0];
   zoom: number = map.DEFAULT_ZOOM;
   private zoomChangeCbs: Array<(zoom: number) => void> = [];
 
   toXZ(latlng: L.LatLng): Point {
-    return [latlng.lng, latlng.lat];
+    return [latlng.lng, 0, latlng.lat];
   }
   fromXZ(pos: Point): L.LatLngExpression {
-    return [pos[1], pos[0]];
+    return [pos[2], pos[0]];
   }
 
   setView(pos: Point, zoom = -1) {

--- a/src/MapBase.ts
+++ b/src/MapBase.ts
@@ -105,7 +105,7 @@ export class MapBase {
         {
           text: 'Copy coordinates',
           callback: ({ latlng }: ui.LeafletContextMenuCbArg) => {
-            const [x, z] = this.toXZ(latlng);
+            const [x, y, z] = this.toXZ(latlng);
             ui.copyToClipboard(`${x},${z}`);
           },
         },

--- a/src/MapMarker.ts
+++ b/src/MapMarker.ts
@@ -218,7 +218,7 @@ export class MapMarkerKorok extends MapMarkerCanvasImpl {
 
   constructor(mb: MapBase, info: any, extra: any) {
     let id = info.id || 'Korok';
-    super(mb, `${id}`, [info.Translate.X, info.Translate.Z], {
+    super(mb, `${id}`, [info.Translate.X, info.Translate.Y, info.Translate.Z], {
       icon: KOROK_ICON,
       iconWidth: 20,
       iconHeight: 20,
@@ -329,8 +329,8 @@ export class MapMarkerObj extends MapMarkerCanvasImpl {
             minz = math.clamp(minz, -4000, 4000);
             maxz = math.clamp(maxz, -4000, 4000);
 
-            const pt1 = mb.fromXZ([minx, minz]);
-            const pt2 = mb.fromXZ([maxx, maxz]);
+            const pt1 = mb.fromXZ([minx, 0, minz]);
+            const pt2 = mb.fromXZ([maxx, 0, maxz]);
             const rect = L.rectangle(L.latLngBounds(pt1, pt2), {
               color: "#ff7800",
               weight: 2,

--- a/src/MapMarker.ts
+++ b/src/MapMarker.ts
@@ -315,7 +315,7 @@ export class MapMarkerObj extends MapMarkerCanvasImpl {
         {
           text: 'Show no-revival area',
           callback: ({ latlng }: ui.LeafletContextMenuCbArg) => {
-            const [x, z] = mb.toXZ(latlng);
+            const [x, y, z] = mb.toXZ(latlng);
             const col = math.clamp(((x + 5000) / 1000) | 0, 0, 9);
             const row = math.clamp(((z + 4000) / 1000) | 0, 0, 7);
 

--- a/src/MapMarker.ts
+++ b/src/MapMarker.ts
@@ -29,10 +29,10 @@ export abstract class MapMarker {
 }
 
 class MapMarkerImpl extends MapMarker {
-  constructor(mb: MapBase, title: string, xz: Point, options: L.MarkerOptions = {}) {
+  constructor(mb: MapBase, title: string, xyz: Point, options: L.MarkerOptions = {}) {
     super(mb);
     this.title = title;
-    this.marker = L.marker(this.mb.fromXZ(xz), Object.assign(options, {
+    this.marker = L.marker(this.mb.fromXYZ(xyz), Object.assign(options, {
       title,
       contextmenu: true,
     }));
@@ -60,7 +60,7 @@ class MapMarkerCanvasImpl extends MapMarker {
     if (options.className) {
       extra['className'] = options.className;
     }
-    this.marker = new CanvasMarker(mb.fromXZ(pos), Object.assign(options, {
+    this.marker = new CanvasMarker(mb.fromXYZ(pos), Object.assign(options, {
       bubblingMouseEvents: false,
       contextmenu: true,
     }));
@@ -96,7 +96,7 @@ class MapMarkerGenericLocationMarker extends MapMarkerImpl {
     const [icon, label] = MapMarkerGenericLocationMarker.ICONS_AND_LABELS[lm.getIcon()];
     const msgId = lm.getMessageId();
     const msg = msgId ? MsgMgr.getInstance().getMsgWithFile('StaticMsg/LocationMarker', msgId) : label;
-    super(mb, msg, lm.getXZ(), {
+    super(mb, msg, lm.getXYZ(), {
       icon,
       zIndexOffset,
     });
@@ -132,7 +132,7 @@ export class MapMarkerLocation extends MapMarkerCanvasImpl {
     const visibleMarkerTypeStr = l.PointerType ? 'Place' : markerTypeStr;
     const msg = MsgMgr.getInstance().getMsgWithFile('StaticMsg/LocationMarker', lp.getMessageId());
 
-    super(mb, msg, lp.getXZ(), { stroke: false, fill: false });
+    super(mb, msg, lp.getXYZ(), { stroke: false, fill: false });
     this.marker.unbindTooltip();
     this.marker.bindTooltip(msg + `<span class="location-marker-type">${visibleMarkerTypeStr}</span>`, {
       permanent: true,
@@ -315,7 +315,7 @@ export class MapMarkerObj extends MapMarkerCanvasImpl {
         {
           text: 'Show no-revival area',
           callback: ({ latlng }: ui.LeafletContextMenuCbArg) => {
-            const [x, y, z] = mb.toXZ(latlng);
+            const [x, y, z] = mb.toXYZ(latlng);
             const col = math.clamp(((x + 5000) / 1000) | 0, 0, 9);
             const row = math.clamp(((z + 4000) / 1000) | 0, 0, 7);
 
@@ -329,8 +329,8 @@ export class MapMarkerObj extends MapMarkerCanvasImpl {
             minz = math.clamp(minz, -4000, 4000);
             maxz = math.clamp(maxz, -4000, 4000);
 
-            const pt1 = mb.fromXZ([minx, 0, minz]);
-            const pt2 = mb.fromXZ([maxx, 0, maxz]);
+            const pt1 = mb.fromXYZ([minx, 0, minz]);
+            const pt2 = mb.fromXYZ([maxx, 0, maxz]);
             const rect = L.rectangle(L.latLngBounds(pt1, pt2), {
               color: "#ff7800",
               weight: 2,

--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -304,7 +304,7 @@ export default class AppMap extends mixins(MixinUtil) {
   initMapRouteIntegration() {
     this.setViewFromRoute(this.$route);
     this.map.zoom = this.map.m.getZoom();
-    this.map.center = this.map.toXZ(this.map.m.getCenter());
+    this.map.center = this.map.toXYZ(this.map.m.getCenter());
     this.map.registerMoveEndCb(() => this.updateRoute());
     this.map.registerZoomEndCb(() => this.updateRoute());
     this.updateRoute();
@@ -656,8 +656,8 @@ export default class AppMap extends mixins(MixinUtil) {
     if (!this.greatPlateauBarrierShown) {
       const RESPAWN_POS: Point = [-1021.7286376953125, 0, 1792.6009521484375];
       const respawnPosMarker = new MapMarkers.MapMarkerPlateauRespawnPos(this.map, RESPAWN_POS);
-      const topLeft = this.map.fromXZ([-1600, 0, 1400]);
-      const bottomRight = this.map.fromXZ([-350, 0, 2400]);
+      const topLeft = this.map.fromXYZ([-1600, 0, 1400]);
+      const bottomRight = this.map.fromXYZ([-350, 0, 2400]);
       const rect = L.rectangle(L.latLngBounds(topLeft, bottomRight), {
         fill: false,
         stroke: true,
@@ -681,11 +681,11 @@ export default class AppMap extends mixins(MixinUtil) {
     this.map.setView([-965, 0.0, 1875], 5);
   }
 
-  gotoOnSubmit(xz: Point) {
-    this.map.setView(xz);
+  gotoOnSubmit(xyz: Point) {
+    this.map.setView(xyz);
     if (this.previousGotoMarker)
       this.previousGotoMarker.remove();
-    this.previousGotoMarker = L.marker(this.map.fromXZ(xz), {
+    this.previousGotoMarker = L.marker(this.map.fromXYZ(xyz), {
       // @ts-ignore
       contextmenu: true,
       contextmenuItems: [{
@@ -847,10 +847,10 @@ export default class AppMap extends mixins(MixinUtil) {
 
       // @ts-ignore
       const latlng: L.LatLng = e.latlng;
-      const xz = this.map.toXZ(latlng);
-      if (!map.isValidPoint(xz))
+      const xyz = this.map.toXYZ(latlng);
+      if (!map.isValidPoint(xyz))
         return;
-      this.searchAddGroup(`map:"${mapType}/${map.pointToMapUnit(xz)}"`);
+      this.searchAddGroup(`map:"${mapType}/${map.pointToMapUnit(xyz)}"`);
     });
   }
 
@@ -997,7 +997,7 @@ export default class AppMap extends mixins(MixinUtil) {
       for (let j = 0; j < 8; ++j) {
         const topLeft: Point = [-5000.0 + i * 1000.0, 0.0, -4000.0 + j * 1000.0];
         const bottomRight: Point = [-5000.0 + (i + 1) * 1000.0, 0.0, -4000.0 + (j + 1) * 1000.0];
-        const rect = L.rectangle(L.latLngBounds(this.map.fromXZ(topLeft), this.map.fromXZ(bottomRight)), {
+        const rect = L.rectangle(L.latLngBounds(this.map.fromXYZ(topLeft), this.map.fromXYZ(bottomRight)), {
           fill: true,
           stroke: true,
           color: '#009dff',

--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -280,7 +280,7 @@ export default class AppMap extends mixins(MixinUtil) {
     if (isNaN(zoom))
       zoom = 3;
 
-    this.map.setView([x, z], zoom);
+    this.map.setView([x, 0, z], zoom);
   }
   updateRoute() {
     this.updatingRoute = true;
@@ -654,10 +654,10 @@ export default class AppMap extends mixins(MixinUtil) {
 
   showGreatPlateauBarrier() {
     if (!this.greatPlateauBarrierShown) {
-      const RESPAWN_POS: Point = [-1021.7286376953125, 1792.6009521484375];
+      const RESPAWN_POS: Point = [-1021.7286376953125, 0, 1792.6009521484375];
       const respawnPosMarker = new MapMarkers.MapMarkerPlateauRespawnPos(this.map, RESPAWN_POS);
-      const topLeft = this.map.fromXZ([-1600, 1400]);
-      const bottomRight = this.map.fromXZ([-350, 2400]);
+      const topLeft = this.map.fromXZ([-1600, 0, 1400]);
+      const bottomRight = this.map.fromXZ([-350, 0, 2400]);
       const rect = L.rectangle(L.latLngBounds(topLeft, bottomRight), {
         fill: false,
         stroke: true,
@@ -678,7 +678,7 @@ export default class AppMap extends mixins(MixinUtil) {
       respawnPosMarker.getMarker().addTo(this.map.m);
       this.greatPlateauBarrierShown = true;
     }
-    this.map.setView([-965, 1875], 5);
+    this.map.setView([-965, 0.0, 1875], 5);
   }
 
   gotoOnSubmit(xz: Point) {
@@ -995,8 +995,8 @@ export default class AppMap extends mixins(MixinUtil) {
   initMapUnitGrid() {
     for (let i = 0; i < 10; ++i) {
       for (let j = 0; j < 8; ++j) {
-        const topLeft: Point = [-5000.0 + i * 1000.0, -4000.0 + j * 1000.0];
-        const bottomRight: Point = [-5000.0 + (i + 1) * 1000.0, -4000.0 + (j + 1) * 1000.0];
+        const topLeft: Point = [-5000.0 + i * 1000.0, 0.0, -4000.0 + j * 1000.0];
+        const bottomRight: Point = [-5000.0 + (i + 1) * 1000.0, 0.0, -4000.0 + (j + 1) * 1000.0];
         const rect = L.rectangle(L.latLngBounds(this.map.fromXZ(topLeft), this.map.fromXZ(bottomRight)), {
           fill: true,
           stroke: true,

--- a/src/components/AppMapDetailsObj.ts
+++ b/src/components/AppMapDetailsObj.ts
@@ -286,7 +286,7 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj | M
 
     const mb = this.marker.data.mb;
     const [x, y, z] = obj.data.Translate;
-    const areaMarker = L.circle(mb.fromXZ([x, z]), { radius }).addTo(mb.m);
+    const areaMarker = L.circle(mb.fromXZ([x, 0, z]), { radius }).addTo(mb.m);
     areaMarker.bringToBack();
     this.areaMarkers.push(areaMarker);
   }
@@ -307,14 +307,14 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj | M
     // A lot of shapes do not use any rotate feature though,
     // and for those this naïve approach should suffice.
     if (shape == 'Sphere') {
-      areaMarker = L.circle(mb.fromXZ([x, z]), { radius: scale[0] }).addTo(mb.m);
+      areaMarker = L.circle(mb.fromXZ([x, 0, z]), { radius: scale[0] }).addTo(mb.m);
     } else if (shape == 'Cylinder' || shape == 'Capsule') {
       if (rotate && Math.abs(rotate[0] - 1.57080) <= 0.01) {
         const southWest = L.latLng(z + scale[2], x - scale[1] - scale[2]);
         const northEast = L.latLng(z - scale[2], x + scale[1] + scale[2]);
         areaMarker = L.rectangle(L.latLngBounds(southWest, northEast)).addTo(mb.m);
       } else {
-        areaMarker = L.circle(mb.fromXZ([x, z]), { radius: scale[0] }).addTo(mb.m);
+        areaMarker = L.circle(mb.fromXZ([x, 0, z]), { radius: scale[0] }).addTo(mb.m);
       }
     } else if (shape == 'Box') {
       const southWest = L.latLng(z + scale[2], x - scale[0]);

--- a/src/components/AppMapDetailsObj.ts
+++ b/src/components/AppMapDetailsObj.ts
@@ -286,7 +286,7 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj | M
 
     const mb = this.marker.data.mb;
     const [x, y, z] = obj.data.Translate;
-    const areaMarker = L.circle(mb.fromXZ([x, 0, z]), { radius }).addTo(mb.m);
+    const areaMarker = L.circle(mb.fromXYZ([x, 0, z]), { radius }).addTo(mb.m);
     areaMarker.bringToBack();
     this.areaMarkers.push(areaMarker);
   }
@@ -307,14 +307,14 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj | M
     // A lot of shapes do not use any rotate feature though,
     // and for those this naïve approach should suffice.
     if (shape == 'Sphere') {
-      areaMarker = L.circle(mb.fromXZ([x, 0, z]), { radius: scale[0] }).addTo(mb.m);
+      areaMarker = L.circle(mb.fromXYZ([x, 0, z]), { radius: scale[0] }).addTo(mb.m);
     } else if (shape == 'Cylinder' || shape == 'Capsule') {
       if (rotate && Math.abs(rotate[0] - 1.57080) <= 0.01) {
         const southWest = L.latLng(z + scale[2], x - scale[1] - scale[2]);
         const northEast = L.latLng(z - scale[2], x + scale[1] + scale[2]);
         areaMarker = L.rectangle(L.latLngBounds(southWest, northEast)).addTo(mb.m);
       } else {
-        areaMarker = L.circle(mb.fromXZ([x, 0, z]), { radius: scale[0] }).addTo(mb.m);
+        areaMarker = L.circle(mb.fromXYZ([x, 0, z]), { radius: scale[0] }).addTo(mb.m);
       }
     } else if (shape == 'Box') {
       const southWest = L.latLng(z + scale[2], x - scale[0]);

--- a/src/components/ModalGotoCoords.ts
+++ b/src/components/ModalGotoCoords.ts
@@ -38,11 +38,11 @@ export default class ModalGotoCoords extends Vue {
   private onSubmit() {
     const x = parseFloat(this.x);
     const z = parseFloat(this.z);
-    if (isNaN(x) || isNaN(z) || !map.isValidXZ(x, z)) {
+    if (isNaN(x) || isNaN(z) || !map.isValidXZ(x, 0, z)) {
       alert("Invalid coordinates");
       return;
     }
-    this.$emit('submitted', [x, z]);
+    this.$emit('submitted', [x, 0, z]);
     this.x = this.z = "";
     this.hide();
   }

--- a/src/components/ModalGotoCoords.ts
+++ b/src/components/ModalGotoCoords.ts
@@ -38,7 +38,7 @@ export default class ModalGotoCoords extends Vue {
   private onSubmit() {
     const x = parseFloat(this.x);
     const z = parseFloat(this.z);
-    if (isNaN(x) || isNaN(z) || !map.isValidXZ(x, 0, z)) {
+    if (isNaN(x) || isNaN(z) || !map.isValidXYZ(x, 0, z)) {
       alert("Invalid coordinates");
       return;
     }

--- a/src/services/MapMgr.ts
+++ b/src/services/MapMgr.ts
@@ -30,7 +30,7 @@ export interface ObjectMinData {
   name: string;
   drop?: [ObjectDropType, string];
   equip?: string[];
-  pos: [number, number];
+  pos: [number, number, number];
 
   // False if not present.
   hard_mode?: boolean;

--- a/src/util/map.ts
+++ b/src/util/map.ts
@@ -4,7 +4,7 @@ export const MAP_SIZE = [24000, 20000];
 export type Point = [number, number, number];
 
 export function isValidXYZ(x: number, y: number, z: number) {
-  return Math.abs(x) <= 6000 && Math.abs(z) <= 5000 && Math.abs(y) <= 2000;
+  return Math.abs(x) <= 6000 && Math.abs(z) <= 5000;
 }
 
 export function isValidPoint(p: Point) {

--- a/src/util/map.ts
+++ b/src/util/map.ts
@@ -3,12 +3,12 @@ export const MAP_SIZE = [24000, 20000];
 
 export type Point = [number, number, number];
 
-export function isValidXZ(x: number, y: number, z: number) {
+export function isValidXYZ(x: number, y: number, z: number) {
   return Math.abs(x) <= 6000 && Math.abs(z) <= 5000 && Math.abs(y) <= 2000;
 }
 
 export function isValidPoint(p: Point) {
-  return isValidXZ(p[0], p[1], p[2]);
+  return isValidXYZ(p[0], p[1], p[2]);
 }
 
 export function pointToMapUnit(p: Point) {
@@ -68,7 +68,7 @@ export class LocationMarkerBase {
   }
 
   getMessageId(): string { return this.l.MessageID; }
-  getXZ(): Point { return [this.l.Translate.X, this.l.Translate.Y, this.l.Translate.Z]; }
+  getXYZ(): Point { return [this.l.Translate.X, this.l.Translate.Y, this.l.Translate.Z]; }
 }
 
 export class LocationMarker extends LocationMarkerBase {

--- a/src/util/map.ts
+++ b/src/util/map.ts
@@ -1,14 +1,14 @@
 export const TILE_SIZE = 256;
 export const MAP_SIZE = [24000, 20000];
 
-export type Point = [number, number];
+export type Point = [number, number, number];
 
-export function isValidXZ(x: number, z: number) {
-  return Math.abs(x) <= 6000 && Math.abs(z) <= 5000;
+export function isValidXZ(x: number, y: number, z: number) {
+  return Math.abs(x) <= 6000 && Math.abs(z) <= 5000 && Math.abs(y) <= 2000;
 }
 
 export function isValidPoint(p: Point) {
-  return isValidXZ(p[0], p[1]);
+  return isValidXZ(p[0], p[1], p[2]);
 }
 
 export function pointToMapUnit(p: Point) {
@@ -68,7 +68,7 @@ export class LocationMarkerBase {
   }
 
   getMessageId(): string { return this.l.MessageID; }
-  getXZ(): Point { return [this.l.Translate.X, this.l.Translate.Z]; }
+  getXZ(): Point { return [this.l.Translate.X, this.l.Translate.Y, this.l.Translate.Z]; }
 }
 
 export class LocationMarker extends LocationMarkerBase {

--- a/src/util/map.ts
+++ b/src/util/map.ts
@@ -13,7 +13,7 @@ export function isValidPoint(p: Point) {
 
 export function pointToMapUnit(p: Point) {
   const col = ((p[0] + 5000) / 1000) >>> 0;
-  const row = ((p[1] + 4000) / 1000) >>> 0;
+  const row = ((p[2] + 4000) / 1000) >>> 0;
   return String.fromCharCode('A'.charCodeAt(0) + col)
     + '-'
     + String.fromCharCode('1'.charCodeAt(0) + row);


### PR DESCRIPTION
Updated positions and `Point` to be `[x, y, z]`.  This is in conjunction with updates on the backend where the `pos` field now returns `[x, y, z]`, y (height) added.

Checked:
- Search Results
- Add To Map (from search result)
- Marker Locations, e.g. Towers, Koroks, ...
- Field Areas and Item Auto Placement (but they should not be impacted)
- Drawing (Markers, Lines, ...) Import and Export
- Go To Coordinates
- Great Plateau Barrier
- Copy Coordinates

Functions and variables renamed from `xz` to `xyz`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/68)
<!-- Reviewable:end -->
