### PR TITLE
Added option to show heights (y-values) as permanent tooltips

### DIFF
--- a/src/MapSearch.ts
+++ b/src/MapSearch.ts
@@ -119,6 +119,10 @@ export class SearchResultGroup {
     return this.markers.data ? this.markers.data.length : 0;
   }
 
+  getMarkers() {
+    return this.markers.data;
+  }
+
   remove() {
     this.markerGroup.data.remove();
     this.markerGroup.data.clearLayers();

--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -254,6 +254,7 @@ export default class AppMap extends mixins(MixinUtil) {
   areaWhitelist = '';
   showKorokIDs = false;
   shownAutoItem = '';
+  staticTooltip = false;
 
   private mapUnitGrid = new ui.Unobservable(L.layerGroup());
   showMapUnitGrid = false;
@@ -789,6 +790,7 @@ export default class AppMap extends mixins(MixinUtil) {
     await group.init(this.map);
     group.update(SearchResultUpdateMode.UpdateStyle | SearchResultUpdateMode.UpdateVisibility, this.searchExcludedSets);
     this.searchGroups.push(group);
+    this.updateTooltip();
   }
 
   searchToggleGroupEnabledStatus(idx: number) {
@@ -834,7 +836,48 @@ export default class AppMap extends mixins(MixinUtil) {
       marker.data.getMarker().addTo(this.map.m);
     }
 
+    this.updateTooltip();
     this.searching = false;
+  }
+
+  yTooltipOnEach(marker: any) {
+    let m: any = marker.getMarker();
+    if (!('_tooltip' in marker.obj)) {
+      // @ts-ignore
+      let tt = m.getTooltip();
+      marker.obj._tooltip = tt.getContent();
+      marker.obj._tooltip_options = tt.options;
+    }
+    m.unbindTooltip();
+    m.bindTooltip(`${marker.obj.pos[1]}`, { permanent: true });
+    m.openTooltip();
+  }
+
+  yTooltipOffEach(marker: any) {
+    let m: any = marker.getMarker();
+    m.getTooltip().options.permanent = false;
+    m.unbindTooltip();
+    m.bindTooltip(marker.obj._tooltip, marker.obj._tooltip_options);
+    m.closeTooltip();
+  }
+
+  yTooltipSwitch(on: boolean) {
+    let func = (on) ? this.yTooltipOnEach : this.yTooltipOffEach;
+    this.searchResultMarkers.map(m => m.data).forEach(func);
+    this.searchGroups.forEach(group => {
+      group.getMarkers().forEach(func);
+    });
+  }
+
+  updateTooltip() {
+    if (this.staticTooltip) {
+      this.yTooltipSwitch(this.staticTooltip);
+    }
+  }
+
+  toggleY() {
+    this.staticTooltip = !this.staticTooltip;
+    this.yTooltipSwitch(this.staticTooltip);
   }
 
   initContextMenu() {
@@ -857,6 +900,9 @@ export default class AppMap extends mixins(MixinUtil) {
   initEvents() {
     this.$on('AppMap:switch-pane', (pane: string) => {
       this.switchPane(pane);
+    });
+    this.$on('AppMap:toggle-y-values', () => {
+      this.toggleY();
     });
 
     this.$on('AppMap:open-obj', async (obj: ObjectData) => {

--- a/src/components/AppMapSettings.ts
+++ b/src/components/AppMapSettings.ts
@@ -46,6 +46,10 @@ export default class AppMapSettings extends Vue {
     this.loadSettings();
   }
 
+  toggleY() {
+    this.$parent.$emit('AppMap:toggle-y-values');
+  }
+
   private loadSettings() {
     this.colorMode = Settings.getInstance().colorPerActor ? 'per-actor' : 'per-group';
   }

--- a/src/components/AppMapSettings.vue
+++ b/src/components/AppMapSettings.vue
@@ -22,6 +22,7 @@
     <p class="mb-1">Some changes only take effect after a reload.</p>
     <b-checkbox switch v-model="s.useActorNames">Use internal actor names</b-checkbox>
     <b-checkbox switch v-model="s.useHexForHashIds">Show hash IDs in hex</b-checkbox>
+    <b-checkbox switch  @change="toggleY">Show object heights in tooltips</b-checkbox>
     <hr>
     <section>
       <h4 class="subsection-heading">Custom Search Presets</h4>


### PR DESCRIPTION
Added option to show heights (y-values) as permanent tooltips

This option is in the Settings pane

To update the tooltip with the permanent flag, we needed to unbind() then re-bind() the tooltip with a different permanent flag value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/69)
<!-- Reviewable:end -->
