### PR TITLE
Add Korok Type List in Filter Pane

### DIFF
--- a/src/MapMarker.ts
+++ b/src/MapMarker.ts
@@ -218,12 +218,13 @@ export class MapMarkerKorok extends MapMarkerCanvasImpl {
 
   constructor(mb: MapBase, info: any, extra: any) {
     let id = info.id || 'Korok';
+    extra.styleLabel = (extra.styleLabel !== undefined) ? extra.styleLabel : true;
     super(mb, `${id}`, [info.Translate.X, info.Translate.Y, info.Translate.Z], {
       icon: KOROK_ICON,
       iconWidth: 20,
       iconHeight: 20,
       showLabel: extra.showLabel,
-      className: classToColor(id),
+      className: (extra.styleLabel) ? classToColor(id) : "default",
     });
     this.info = info;
     // @ts-ignore

--- a/src/MapSearch.ts
+++ b/src/MapSearch.ts
@@ -37,6 +37,43 @@ function makeNameQuery(names: string[]): string {
   return names.map(x => `name:"^${x}"`).join(' OR ');
 }
 
+export const KOROK_TYPES =
+  [
+    "Acorn in a Hole",
+    "Ball and Chain",
+    "Burn the Leaves",
+    "Circle of Rocks",
+    "Cube Puzzle",
+    "Dive",
+    "Flower Order",
+    "Flower Trail",
+    "Goal Ring",
+    "Hanging Acorn",
+    "Jump the Fences",
+    "Light Torch",
+    "Matching Trees",
+    "Melt Ice Block",
+    "Moving Lights",
+    "Offering Plate",
+    "Pinwheel Acorns",
+    "Pinwheel Balloons",
+    "Remove Luminous Stone",
+    "Rock Lift",
+    "Rock Lift (Boulder)",
+    "Rock Lift (Door)",
+    "Rock Lift (Leaves)",
+    "Rock Lift (Rock Pile)",
+    "Rock Lift (Slab)",
+    "Rock Pattern",
+    "Roll a Boulder",
+    "Shoot the Crest",
+    "Shoot the Targets",
+    "Stationary Balloon",
+    "Stationary Lights",
+    "Take Apple from Palm Tree",
+    "Take the Stick",
+  ];
+
 export const SEARCH_PRESETS: ReadonlyArray<SearchPresetGroup> = Object.freeze([
   {
     label: '<i class="far fa-gem"></i>',

--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -20,7 +20,7 @@ import * as MapIcons from '@/MapIcon';
 import * as MapMarkers from '@/MapMarker';
 import { MapMarker, SearchResultUpdateMode } from '@/MapMarker';
 import { MapMarkerGroup } from '@/MapMarkerGroup';
-import { SearchResultGroup, SearchExcludeSet, SEARCH_PRESETS } from '@/MapSearch';
+import { SearchResultGroup, SearchExcludeSet, SEARCH_PRESETS, KOROK_TYPES } from '@/MapSearch';
 import * as save from '@/save';
 
 import MixinUtil from '@/components/MixinUtil';
@@ -240,6 +240,9 @@ export default class AppMap extends mixins(MixinUtil) {
   private searchResultMarkers: ui.Unobservable<MapMarkers.MapMarkerSearchResult>[] = [];
   private searchGroups: SearchResultGroup[] = [];
   private searchPresets = SEARCH_PRESETS;
+  private korokTypes = KOROK_TYPES;
+  private korokTypeOn = KOROK_TYPES.map(t => false);
+  private korokTypeOpen: boolean = false;
   private searchExcludedSets: SearchExcludeSet[] = [];
   private readonly MAX_SEARCH_RESULT_COUNT = 2000;
 
@@ -802,6 +805,42 @@ export default class AppMap extends mixins(MixinUtil) {
     const group = this.searchGroups[idx];
     this.searchQuery = group.query;
     this.search();
+  }
+
+  async addKorokType(name: string, query: string) {
+    let objs = await MapMgr.getInstance().getObjs(this.settings!.mapType,
+      this.settings!.mapName, query);
+    objs.forEach((obj: any) => {
+      obj.Translate = { X: obj.pos[0], Y: obj.pos[1], Z: obj.pos[2] };
+      obj.id = obj.korok_type;
+    });
+    let group = new MapMarkerGroup(
+      objs.map((m: any) =>
+        new MapMarkers.MapMarkerKorok(this.map, m, {
+          showLabel: this.showKorokIDs,
+          styleLabel: false
+        })),
+      1.0, false);
+    this.markerGroups.set(name, group);
+    group.addToMap(this.map.m);
+
+    for (const group of this.markerGroups.values())
+      group.update();
+
+  }
+
+  searchToggleGroup(name: string) {
+    const ROCK_LIFT_QUERY = 'korok_type: "Rock Lift" NOT Leaves NOT Pile NOT Slab NOT Door NOT Boulder';
+    let query = `korok_type: "${name}"`;
+    if (name == "Rock Lift") {
+      query = ROCK_LIFT_QUERY;
+    }
+    if (this.markerGroups.has(name)) {
+      this.markerGroups.get(name)!.destroy();
+      this.markerGroups.delete(name);
+    } else {
+      this.addKorokType(name, query);
+    }
   }
 
   searchRemoveGroup(idx: number) {

--- a/src/components/AppMap.vue
+++ b/src/components/AppMap.vue
@@ -139,6 +139,14 @@
           <AppMapFilterMainButton v-for="(v, type) in markerComponents" :key="type" :type="type" :label="v.filterLabel" :icon="v.filterIcon" @toggle="updateMarkers" />
         </div>
         <b-checkbox switch v-model="showKorokIDs" @change="updateKorokIDs">Show Korok IDs</b-checkbox>
+        <b-checkbox v-model="korokTypeOpen"  switch >Korok Types</b-checkbox>
+
+        <b-collapse id="korokTypesList" class="mt-2" v-model="korokTypeOpen">
+          <b-card style="background: rgba(0,0,0,0); overflow-y: scroll; max-height: 300px; border:1px solid #333;">
+            <b-checkbox v-for="(ktype, index) in korokTypes" :key="ktype" ref="koroks" v-model="korokTypeOn[index]" :checked=false switch @input='searchToggleGroup(ktype)'>{{ktype}}</b-checkbox>
+          </b-card>
+        </b-collapse>
+
         <hr>
         <h4 class="subsection-heading">Visible map areas</h4>
         <b-radio-group stacked class="mb-4" v-model="shownAreaMap" @change="onShownAreaMapChanged">

--- a/src/components/ObjectInfo.vue
+++ b/src/components/ObjectInfo.vue
@@ -40,6 +40,7 @@
       <span v-if="data.sharp_weapon_judge_type == 4"><i class="far fa-star fa-fw" style="color: tomato"></i> No modifier</span>
     </section>
     <section class="search-result-link" v-if="link"><i class="fa fa-link fa-fw"></i> Link type: {{link.ltype}}</section>
+    <section v-if="data.korok_type">Korok Type: {{data.korok_type}}</section>
   </div>
 </template>
 <style lang="less">

--- a/src/services/MapMgr.ts
+++ b/src/services/MapMgr.ts
@@ -42,6 +42,10 @@ export interface ObjectMinData {
   // Only for weapons and enemies.
   scale?: number;
   sharp_weapon_judge_type?: number;
+
+  // Korok Data
+  korok_id?: string;
+  korok_type?: string;
 }
 
 export interface ObjectData extends ObjectMinData {


### PR DESCRIPTION
Add Korok Type List in Filter Pane

Allows the Display of Specific types of Koroks (Diving, Goal Ring / Race, Rock Lift, ...)

Korok Type names based on https://lepelog.github.io/korokmap/

"Korok Types" Toggle
![Screenshot 2022-02-05 at 14-39-22 BotW Object Map](https://user-images.githubusercontent.com/126514/152656481-7451f7b1-8882-4002-9803-13578f082969.png)

"Korok Types CheckList"
![Screenshot 2022-02-05 at 14-39-43 BotW Object Map](https://user-images.githubusercontent.com/126514/152656484-25014cfb-4a09-4803-8a1a-56683d31b29d.png)

