### PR TITLE
Configurable GAME_FILES constant

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VUE_APP_GAME_FILES=https://objmap.zeldamods.org/game_files

--- a/src/MapBase.ts
+++ b/src/MapBase.ts
@@ -142,12 +142,12 @@ export class MapBase {
     const southWest = this.rc.unproject([0, this.rc.height]);
     const northEast = this.rc.unproject([this.rc.width, 0]);
     const bounds = new L.LatLngBounds(southWest, northEast);
-    const baseImage = L.imageOverlay('/game_files/maptex/base.png', bounds, {
+    const baseImage = L.imageOverlay(`${map.GAME_FILES}/maptex/base.png`, bounds, {
       pane: BASE_PANE,
     });
     baseImage.addTo(this.m);
 
-    const baseLayer = L.tileLayer('/game_files/maptex/{z}/{x}/{y}.png', {
+    const baseLayer = L.tileLayer(`${map.GAME_FILES}/maptex/{z}/{x}/{y}.png`, {
       maxNativeZoom: 7,
     });
     baseLayer.addTo(this.m);

--- a/src/services/MapMgr.ts
+++ b/src/services/MapMgr.ts
@@ -1,3 +1,6 @@
+
+import { GAME_FILES } from '@/util/map';
+
 const RADAR_URL = 'https://radar.zeldamods.org';
 
 export type Vec3 = [number, number, number];
@@ -75,7 +78,7 @@ export class MapMgr {
 
   async init() {
     await Promise.all([
-      fetch('/game_files/map_summary/MainField/static.json').then(r => r.json())
+      fetch(`${GAME_FILES}/map_summary/MainField/static.json`).then(r => r.json())
         .then((d) => {
           d.markers["DungeonDLC"] = d.markers["Dungeon"].filter((l: any) => parseInt(l.SaveFlag.replace('Location_Dungeon', ''), 10) >= 120);
           d.markers["Dungeon"] = d.markers["Dungeon"].filter((l: any) => parseInt(l.SaveFlag.replace('Location_Dungeon', ''), 10) < 120);
@@ -85,7 +88,7 @@ export class MapMgr {
   }
 
   fetchAreaMap(name: string): Promise<{ [data: number]: Array<GeoJSON.Polygon | GeoJSON.MultiPolygon> }> {
-    return fetch(`/game_files/ecosystem/${name}.json`).then(parse);
+    return fetch(`${GAME_FILES}/ecosystem/${name}.json`).then(parse);
   }
 
   getInfoMainField() {

--- a/src/services/MsgMgr.ts
+++ b/src/services/MsgMgr.ts
@@ -1,3 +1,5 @@
+import { GAME_FILES } from '@/util/map';
+
 type File = { [label: string]: string };
 
 export class MsgMgr {
@@ -12,7 +14,7 @@ export class MsgMgr {
   private files: Map<string, File> = new Map();
 
   async init() {
-    const PREFIX = '/game_files/text/';
+    const PREFIX = `${GAME_FILES}/text/`;
     const fileList: string[] = await fetch(PREFIX + 'list.json').then(r => r.json());
     const fileLoadPromises = [];
     for (const path of fileList) {
@@ -21,7 +23,7 @@ export class MsgMgr {
         this.files.set(file, Object.freeze(d));
       }));
     }
-    fileLoadPromises.push(fetch('/game_files/names.json').then(r => r.json()).then((d) => {
+    fileLoadPromises.push(fetch(`${GAME_FILES}/names.json`).then(r => r.json()).then((d) => {
       this.names = d;
     }));
     await Promise.all(fileLoadPromises);

--- a/src/util/map.ts
+++ b/src/util/map.ts
@@ -1,7 +1,7 @@
 export const TILE_SIZE = 256;
 export const MAP_SIZE = [24000, 20000];
 
-export const GAME_FILES = "https://objmap.zeldamods.org/game_files";
+export const GAME_FILES = process.env.VUE_APP_GAME_FILES;
 
 export type Point = [number, number, number];
 

--- a/src/util/map.ts
+++ b/src/util/map.ts
@@ -1,6 +1,8 @@
 export const TILE_SIZE = 256;
 export const MAP_SIZE = [24000, 20000];
 
+export const GAME_FILES = "https://objmap.zeldamods.org/game_files";
+
 export type Point = [number, number, number];
 
 export function isValidXYZ(x: number, y: number, z: number) {


### PR DESCRIPTION
Made `GAME_FILES` configurable via an `.env` file (provided). Users can create their own `.env.*` files to use a different (eg. local) URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/76)
<!-- Reviewable:end -->
