### PR TITLE
Tell eslint to ignore the use of console.error

### DIFF
--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -296,6 +296,7 @@ export default class AppMap extends mixins(MixinUtil) {
       query: this.$route.query,
     }).catch(err => {
       if (!isNavigationFailure(err, NavigationFailureType.duplicated)) {
+        // eslint-disable-next-line no-console
         console.error(err);
       }
     });


### PR DESCRIPTION
This affects production builds; debug builds always have `no-console` and `no-debugger` disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/78)
<!-- Reviewable:end -->
