### PR TITLE
Add Clear All Confirm Dialog

### DIFF
--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -507,6 +507,12 @@ export default class AppMap extends mixins(MixinUtil) {
           layerSetTooltip(layer);
         });
       },
+      'draw:deleted': (e: any) => {
+        let ans = confirm("Clear all map items?");
+        if (!ans) {
+          e.layers.eachLayer((layer: L.Marker | L.Polyline) => this.drawLayer.addLayer(layer));
+        }
+      },
     });
     this.drawOnColorChange({});
     Settings.getInstance().registerBeforeSaveCallback(() => {


### PR DESCRIPTION
Added "Clear All" confirm dialog.

The [Leaflet.draw](https://github.com/Leaflet/Leaflet.draw) module immediately deletes all layers on the "Clear all" button click.  Leaflet.draw returns all of the deleted layers (Markers and Polylines) to the "draw:deleted" event handler. We use this to re-add the layers back if the user would like to keep the layers.

@iTNTPiston

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/81)
<!-- Reviewable:end -->
