### PR TITLE
 Add ability to show Flower Trail Korok Paths 

### DIFF
--- a/src/components/AppMapDetailsObj.ts
+++ b/src/components/AppMapDetailsObj.ts
@@ -508,7 +508,7 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj | M
   hideKoroks() {
     let map = this.marker.data.mb;
     this.staticData.persistentKorokMarkers.forEach(m => {
-      m.forEach(marker => marker.remove());
+      m.forEach((marker: any) => marker.remove());
     });
     this.staticData.persistentKorokMarkers = [];
     this.korokMarkers = [];

--- a/src/components/AppMapDetailsObj.vue
+++ b/src/components/AppMapDetailsObj.vue
@@ -19,6 +19,10 @@
         <b-btn v-show="areaMarkers.length" size="sm" block variant="dark" @click="keepAreaMarkersAlive()">Keep area representation loaded</b-btn>
         <b-btn v-show="staticData.persistentAreaMarkers.length" size="sm" block variant="dark" @click="forgetPersistentAreaMarkers()">Hide area representation</b-btn>
       </section>
+      <section class="mt-2" v-show="minObj.korok_type">
+        <b-btn v-show="korokType() && this.korokMarkers.length <= 0" size="sm" block variant="dark" @click="korokDetails()">Keep Korok markers loaded</b-btn>
+        <b-btn v-show="staticData.persistentKorokMarkers.length" size="sm" block variant="dark" @click="hideKoroks()">Hide Korok markers</b-btn>
+      </section>
 
       <section class="obj-actor-specific-info">
         <!-- AreaObserverTag -->

--- a/src/components/ObjectInfo.vue
+++ b/src/components/ObjectInfo.vue
@@ -49,6 +49,10 @@
       <span v-if="data.sharp_weapon_judge_type == 4"><i class="far fa-star fa-fw" style="color: tomato"></i> No modifier</span>
     </section>
     <section class="search-result-link" v-if="link"><i class="fa fa-link fa-fw"></i> Link type: {{link.ltype}}</section>
+    <section class="search-result-yahaha" v-if="data.korok_type">
+      <i class="fas fa-fw fa-leaf" style="color:lightgreen"></i>
+      {{data.korok_id}} - {{ data.korok_type }}
+    </section>
   </div>
 </template>
 <style lang="less">

--- a/src/services/MapMgr.ts
+++ b/src/services/MapMgr.ts
@@ -46,6 +46,9 @@ export interface ObjectMinData {
   // Only for weapons and enemies.
   scale?: number;
   sharp_weapon_judge_type?: number;
+
+  korok_type?: string;
+  korok_id?: string;
 }
 
 export interface ObjectData extends ObjectMinData {


### PR DESCRIPTION
Add ability to show paths of Flower Trail Koroks

Working in a similar way to the Area Representation. 

This also adds the Korok Type and Korok ID to `ObjectInfo.vue` 

![Screenshot 2022-05-07 at 14-30-00 BotW Object Map](https://user-images.githubusercontent.com/126514/167267242-8876b541-d811-405d-84ed-40cffa9c502c.png)

