### PR TITLE
Fix name query preset, replace "^str" with ^"str"

### DIFF
--- a/src/MapSearch.ts
+++ b/src/MapSearch.ts
@@ -34,7 +34,7 @@ function makeActorQuery(actors: string[]): string {
 }
 
 function makeNameQuery(names: string[]): string {
-  return names.map(x => `name:"^${x}"`).join(' OR ');
+  return names.map(x => `name:^"${x}"`).join(' OR ');
 }
 
 export const SEARCH_PRESETS: ReadonlyArray<SearchPresetGroup> = Object.freeze([


### PR DESCRIPTION
The recent update of search broke queries involving names.

Fix is to place the `^` outside of the double quoets, i.e. replace `"^str"` with `^"str"`

See https://discord.com/channels/269611402854006785/269611402854006785/986860878756462612

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/98)
<!-- Reviewable:end -->
