### PR TITLE
Sync korok_id/type if available, was missing on korok marker click

### DIFF
--- a/src/components/AppMapDetailsObj.ts
+++ b/src/components/AppMapDetailsObj.ts
@@ -150,6 +150,13 @@ export default class AppMapDetailsObj extends AppMapDetailsBase<MapMarkerObj | M
       // Set the objid from the fetched data otherwise Vue does not update
       this.minObj.objid = this.obj.objid;
     }
+    if (!this.minObj.korok_type && this.obj.korok_type) {
+      this.minObj.korok_type = this.obj.korok_type;
+    }
+    if (!this.minObj.korok_id && this.obj.korok_id) {
+      this.minObj.korok_id = this.obj.korok_id;
+    }
+
     this.dropTables = await MapMgr.getInstance().getObjDropTables(this.getRankedUpActorNameForObj(this.minObj), this.getDropTableName());
     this.genGroup = await MapMgr.getInstance().getObjGenGroup(this.obj.map_type, this.obj.map_name, this.obj.hash_id);
     for (const obj of this.genGroup) {


### PR DESCRIPTION
Clicking on a Korok marker was missing the data `korok_type` and `korok_id` in `this.minObj`. 

This lead to an inconsistency in the Side Pane information between clicking on a Korok marker and a search result.

This data exists in `this.obj`, so sync these two fields.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/105)
<!-- Reviewable:end -->
