### PR TITLE
Add Life/Durability and Attack/Power to ObjectInfo

### DIFF
--- a/gen_object_meta.py
+++ b/gen_object_meta.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+import os
+import yaml
+import json
+import glob
+
+def u_constrt(loader, node):
+    return node.value
+def io_constrt(loader, node):
+    value = loader.construct_mapping(node)
+    return value
+def list_constrt(loader, node):
+    value = loader.construct_mapping(node)
+    return value
+def obj_constrt(loader, node):
+    value = loader.construct_mapping(node)
+    return value
+def str_constrt(loader, node):
+    return node.value
+def vec3_constrt(loader, node):
+    return node.value
+def color_constrt(loader, node):
+    return node.value
+yaml.add_constructor('!u', u_constrt)
+yaml.add_constructor('!io', io_constrt)
+yaml.add_constructor('!color', color_constrt)
+yaml.add_constructor('!list', list_constrt)
+yaml.add_constructor('!obj', obj_constrt)
+yaml.add_constructor('!str64', str_constrt)
+yaml.add_constructor('!str32', str_constrt)
+yaml.add_constructor('!str256', str_constrt)
+yaml.add_constructor('!vec3', vec3_constrt)
+
+meta = {}
+def add_meta(name, key, value):
+    if not name in meta:
+        meta[name] = {}
+    meta[name][key] = value
+
+def is_npc(name):
+    return name.startswith('Npc_')
+def is_obj(name):
+    return name.startswith('Obj_')
+def is_item(name):
+    return name.startswith('Item_')
+def is_horse(name):
+    return name.startswith('GameRomHorse')
+def is_dummy(name):
+    return name == 'Dummy'
+def is_tree(name):
+    return name.startswith('Tree')
+def is_remain_wind(name):
+    return name.startswith('RemainsWind')
+
+def is_skip(name):
+    return is_npc(name) or is_obj(name) or is_horse(name) or is_dummy(name) or is_tree(name) or is_remain_wind(name)
+
+
+def get_value(data, names):
+    v = data
+    for name in names:
+        if name in v:
+            v = v[name]
+        else :
+            return None
+    return v
+for file in glob.glob(f'Actor/ActorLink/*.yml'):
+    #print(file)
+    with open(file,'r') as f:
+        bdata = yaml.load(f, Loader=yaml.FullLoader)
+
+
+    name = os.path.basename(file).replace('.yml','')
+
+    gpar = get_value(bdata, ['param_root', 'objects', 'LinkTarget', 'GParamUser'])
+    if gpar == 'Dummy' or gpar == 'MessageOnly':
+        continue
+    with open(f"Actor/GeneralParamList/{gpar}.gparamlist.yml", 'r') as f:
+        data = yaml.load(f, Loader=yaml.FullLoader)
+
+    enemy = get_value(data, ['param_root','objects','Enemy'])
+    weapon = get_value(data, ['param_root','objects','WeaponCommon'])
+    if not enemy and not weapon:
+        continue
+    aname = get_value(data, ['param_root', 'objects','System','SameGroupActorName'])
+    #if aname and aname != '':
+    #    name = aname
+        #print(aname)
+    if is_skip(name):
+        continue
+    life = get_value(data, ['param_root', 'objects', 'General','Life'])
+    if life:
+        add_meta(name, 'life', life)
+    attack = get_value(data, ['param_root', 'objects', 'Attack','Power'])
+    if attack:
+        add_meta(name, 'attack', attack)
+    #print(name, life, attack, file)
+json.dump(meta, open('object_meta.json','w'))

--- a/gen_object_meta.py
+++ b/gen_object_meta.py
@@ -5,56 +5,86 @@ import yaml
 import json
 import glob
 
+
 def u_constrt(loader, node):
     return node.value
+
+
 def io_constrt(loader, node):
     value = loader.construct_mapping(node)
     return value
+
+
 def list_constrt(loader, node):
     value = loader.construct_mapping(node)
     return value
+
+
 def obj_constrt(loader, node):
     value = loader.construct_mapping(node)
     return value
+
+
 def str_constrt(loader, node):
     return node.value
+
+
 def vec3_constrt(loader, node):
     return node.value
+
+
 def color_constrt(loader, node):
     return node.value
-yaml.add_constructor('!u', u_constrt)
-yaml.add_constructor('!io', io_constrt)
-yaml.add_constructor('!color', color_constrt)
-yaml.add_constructor('!list', list_constrt)
-yaml.add_constructor('!obj', obj_constrt)
-yaml.add_constructor('!str64', str_constrt)
-yaml.add_constructor('!str32', str_constrt)
-yaml.add_constructor('!str256', str_constrt)
-yaml.add_constructor('!vec3', vec3_constrt)
 
-meta = {}
-def add_meta(name, key, value):
-    if not name in meta:
-        meta[name] = {}
-    meta[name][key] = value
+
+yaml.add_constructor("!u", u_constrt)
+yaml.add_constructor("!io", io_constrt)
+yaml.add_constructor("!color", color_constrt)
+yaml.add_constructor("!list", list_constrt)
+yaml.add_constructor("!obj", obj_constrt)
+yaml.add_constructor("!str64", str_constrt)
+yaml.add_constructor("!str32", str_constrt)
+yaml.add_constructor("!str256", str_constrt)
+yaml.add_constructor("!vec3", vec3_constrt)
+
 
 def is_npc(name):
-    return name.startswith('Npc_')
-def is_obj(name):
-    return name.startswith('Obj_')
-def is_item(name):
-    return name.startswith('Item_')
-def is_horse(name):
-    return name.startswith('GameRomHorse')
-def is_dummy(name):
-    return name == 'Dummy'
-def is_tree(name):
-    return name.startswith('Tree')
-def is_remain_wind(name):
-    return name.startswith('RemainsWind')
+    return name.startswith("Npc_")
 
-def is_skip(name):
-    return is_npc(name) or is_obj(name) or is_horse(name) or is_dummy(name) or is_tree(name) or is_remain_wind(name)
+
+def is_obj(name):
+    return name.startswith("Obj_")
+
+
+def is_item(name):
+    return name.startswith("Item_")
+
+
+def is_horse(name):
+    return name.startswith("GameRomHorse")
+
+
+def is_dummy(name):
+    return name == "Dummy"
+
+
+def is_tree(name):
+    return name.startswith("Tree")
+
+
+def is_remain_wind(name):
+    return name.startswith("RemainsWind")
+
+
+def should_skip(name):
+    return (
+        is_npc(name)
+        or is_obj(name)
+        or is_horse(name)
+        or is_dummy(name)
+        or is_tree(name)
+        or is_remain_wind(name)
+    )
 
 
 def get_value(data, names):
@@ -62,38 +92,56 @@ def get_value(data, names):
     for name in names:
         if name in v:
             v = v[name]
-        else :
+        else:
             return None
     return v
-for file in glob.glob(f'Actor/ActorLink/*.yml'):
-    #print(file)
-    with open(file,'r') as f:
+
+
+meta = {}
+
+
+def add_meta(name, key, value):
+    if not name in meta:
+        meta[name] = {}
+    meta[name][key] = value
+
+
+for file in glob.glob(f"Actor/ActorLink/*.yml"):
+    with open(file, "r") as f:
         bdata = yaml.load(f, Loader=yaml.FullLoader)
 
+    name = os.path.basename(file).replace(".yml", "")
 
-    name = os.path.basename(file).replace('.yml','')
-
-    gpar = get_value(bdata, ['param_root', 'objects', 'LinkTarget', 'GParamUser'])
-    if gpar == 'Dummy' or gpar == 'MessageOnly':
+    gpar = get_value(bdata, ["param_root", "objects", "LinkTarget", "GParamUser"])
+    if gpar == "Dummy" or gpar == "MessageOnly":
         continue
-    with open(f"Actor/GeneralParamList/{gpar}.gparamlist.yml", 'r') as f:
+
+    with open(f"Actor/GeneralParamList/{gpar}.gparamlist.yml", "r") as f:
         data = yaml.load(f, Loader=yaml.FullLoader)
 
-    enemy = get_value(data, ['param_root','objects','Enemy'])
-    weapon = get_value(data, ['param_root','objects','WeaponCommon'])
+    enemy = get_value(data, ["param_root", "objects", "Enemy"])
+    weapon = get_value(data, ["param_root", "objects", "WeaponCommon"])
     if not enemy and not weapon:
         continue
-    aname = get_value(data, ['param_root', 'objects','System','SameGroupActorName'])
-    #if aname and aname != '':
-    #    name = aname
-        #print(aname)
-    if is_skip(name):
+    aname = get_value(data, ["param_root", "objects", "System", "SameGroupActorName"])
+
+    if should_skip(name):
         continue
-    life = get_value(data, ['param_root', 'objects', 'General','Life'])
+    life = get_value(data, ["param_root", "objects", "General", "Life"])
+    if "Enemy_SiteBoss" in file:
+        # See https://zeldamods.org/wiki/Difficulty_scaling#Ganon_Blights
+        if "Weapon" in file:
+            pass
+        elif "Castle" in file:
+            life = 2000
+        elif "_R" in file:
+            life = 1500
+        else:
+            life = "800 - 2000"
     if life:
-        add_meta(name, 'life', life)
-    attack = get_value(data, ['param_root', 'objects', 'Attack','Power'])
+        add_meta(name, "life", life)
+    attack = get_value(data, ["param_root", "objects", "Attack", "Power"])
     if attack:
-        add_meta(name, 'attack', attack)
-    #print(name, life, attack, file)
-json.dump(meta, open('object_meta.json','w'))
+        add_meta(name, "attack", attack)
+
+json.dump(meta, open("object_meta.json", "w"))

--- a/src/components/ObjectInfo.ts
+++ b/src/components/ObjectInfo.ts
@@ -30,6 +30,8 @@ export default class ObjectInfo extends mixins(MixinUtil) {
 
   private data!: ObjectData | ObjectMinData;
 
+  private xmeta: any | null = null;
+
   private created() {
     if ((!this.obj && !this.link) || (this.obj && this.link))
       throw new Error('needs an object *or* a placement link');
@@ -39,6 +41,24 @@ export default class ObjectInfo extends mixins(MixinUtil) {
     if (this.obj)
       this.data = this.obj;
   }
+
+  async get_meta() {
+    if (!this.xmeta) {
+      const rname = this.getRankedUpActorNameForObj(this.data);
+      this.xmeta = await MsgMgr.getInstance().getObjectMetaData(rname);
+    }
+  }
+
+  private meta(item: string) {
+    if (!this.xmeta) {
+      this.get_meta();
+    }
+    if (this.xmeta) {
+      return (this.xmeta[item]) ? this.xmeta[item] : null;
+    }
+    return null;
+  }
+
 
   private name(rankUp: boolean) {
     if (this.dropAsName)

--- a/src/components/ObjectInfo.ts
+++ b/src/components/ObjectInfo.ts
@@ -30,7 +30,7 @@ export default class ObjectInfo extends mixins(MixinUtil) {
 
   private data!: ObjectData | ObjectMinData;
 
-  private xmeta: any | null = null;
+  private metadata: any | null = null;
 
   private created() {
     if ((!this.obj && !this.link) || (this.obj && this.link))
@@ -42,21 +42,17 @@ export default class ObjectInfo extends mixins(MixinUtil) {
       this.data = this.obj;
   }
 
-  async get_meta() {
-    if (!this.xmeta) {
+  async loadMetaIfNeeded() {
+    if (!this.metadata) {
       const rname = this.getRankedUpActorNameForObj(this.data);
-      this.xmeta = await MsgMgr.getInstance().getObjectMetaData(rname);
+      this.metadata = await MsgMgr.getInstance().getObjectMetaData(rname);
     }
   }
 
   private meta(item: string) {
-    if (!this.xmeta) {
-      this.get_meta();
-    }
-    if (this.xmeta) {
-      return (this.xmeta[item]) ? this.xmeta[item] : null;
-    }
-    return null;
+    this.loadMetaIfNeeded();
+    // Return values may still be null if metadata is not available
+    return (this.metadata) ? this.metadata[item] : null;
   }
 
 

--- a/src/components/ObjectInfo.vue
+++ b/src/components/ObjectInfo.vue
@@ -54,13 +54,11 @@
       {{data.korok_id}} - {{ data.korok_type }}
     </section>
     <section class="search-result-life" v-if="meta('life')">
-      <i class="fas fa-fw fa-heart" style="color:tomato"></i> {{meta('life')}}
+      <i class="fas fa-fw fa-heart" style="color:white"></i> {{meta('life')}}
     </section>
     <section class="search-result-life" v-if="meta('attack')">
       <div class="swords fa-fw fa" style="color: white">&#9876;</div> {{meta('attack')}}
     </section>
-
-
   </div>
 </template>
 <style lang="less">
@@ -86,14 +84,16 @@
   font-size: 110%;
   margin-bottom: 3px;
 }
+
 .swords {
     display: inline;
     font-weight: bold;
     font-size: 1.5em;
 }
+
 .search-result-life {
     display: inline-block;
-    padding-right: 0.3em
+    padding-right: 0.3em;
 }
 </style>
 <script src="./ObjectInfo.ts"></script>

--- a/src/components/ObjectInfo.vue
+++ b/src/components/ObjectInfo.vue
@@ -53,6 +53,14 @@
       <i class="fas fa-fw fa-leaf" style="color:lightgreen"></i>
       {{data.korok_id}} - {{ data.korok_type }}
     </section>
+    <section class="search-result-life" v-if="meta('life')">
+      <i class="fas fa-fw fa-heart" style="color:tomato"></i> {{meta('life')}}
+    </section>
+    <section class="search-result-life" v-if="meta('attack')">
+      <div class="swords fa-fw fa" style="color: white">&#9876;</div> {{meta('attack')}}
+    </section>
+
+
   </div>
 </template>
 <style lang="less">
@@ -77,6 +85,15 @@
 .search-result-name {
   font-size: 110%;
   margin-bottom: 3px;
+}
+.swords {
+    display: inline;
+    font-weight: bold;
+    font-size: 1.5em;
+}
+.search-result-life {
+    display: inline-block;
+    padding-right: 0.3em
 }
 </style>
 <script src="./ObjectInfo.ts"></script>

--- a/src/services/MsgMgr.ts
+++ b/src/services/MsgMgr.ts
@@ -68,10 +68,7 @@ export class MsgMgr {
       const res = await fetch(`${GAME_FILES}/object_meta.json`);
       this.metadata = await res.json();
     }
-    if (this.metadata) {
-      return this.metadata[item];
-    }
-    return null;
+    return this.metadata[item];
   }
 
   /// Get a message by its message ID (e.g. EventFlowMsg/AncientBall_Kakariko:Label).

--- a/src/services/MsgMgr.ts
+++ b/src/services/MsgMgr.ts
@@ -14,6 +14,7 @@ export class MsgMgr {
   private files: Map<string, File> = new Map();
   private climate: any | null = null;
   private area: any | null = null;
+  private metadata: any | null = null;
 
   async init() {
     const PREFIX = `${GAME_FILES}/text/`;
@@ -58,6 +59,17 @@ export class MsgMgr {
     }
     if (this.climate) {
       return this.climate[`ClimateDefines_${item}`];
+    }
+    return null;
+  }
+
+  async getObjectMetaData(item: string) {
+    if (!this.metadata) {
+      const res = await fetch(`${GAME_FILES}/object_meta.json`);
+      this.metadata = await res.json();
+    }
+    if (this.metadata) {
+      return this.metadata[item];
     }
     return null;
   }


### PR DESCRIPTION
Add Life/Durability and Attack/Power to ObjectInfo

Adds files:
- public/game_files/object_meta.json (attached)
- gen_object_meta.py (in commit)

Note: I had originally included the data directly as a large object in the source. I then moved it to an external file in game_files.  Another option is adding more database rows, but the level_scaling will likely be an issue.  Including it directly in the source made for simple code; the external file added some async complexity and modifies `MsgMgr`

![Screenshot 2022-12-07 at 17-25-57 BotW Object Map](https://user-images.githubusercontent.com/126514/206325015-1f12f6ad-9d23-4789-944b-f34073cab09a.png)

[object_meta.json.zip](https://github.com/zeldamods/objmap/files/10181060/object_meta.json.zip)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/112)
<!-- Reviewable:end -->
