### PR TITLE
Add Reference Grid based on the undiscovered map sections

### DIFF
--- a/src/MapBase.ts
+++ b/src/MapBase.ts
@@ -10,6 +10,7 @@ import { Point } from '@/util/map';
 import * as ui from '@/util/ui';
 import '@/util/leaflet_tile_workaround.js';
 import { Settings } from './util/settings';
+import { MapMgr } from '@/services/MapMgr';
 
 declare module 'leaflet' {
   export type RasterCoords = any;
@@ -25,6 +26,63 @@ export class MapBase {
   center: Point = [0, 0, 0];
   zoom: number = map.DEFAULT_ZOOM;
   private zoomChangeCbs: Array<(zoom: number) => void> = [];
+  baseLayer!: L.Layer;
+  refGrid: Array<L.LayerGroup> = [];
+  refGridOn: boolean = false;
+
+  showBaseMap(show: boolean) {
+    if (show) {
+      this.m.addLayer(this.baseLayer);
+    } else {
+      this.m.removeLayer(this.baseLayer);
+    }
+  }
+  async loadTowerAreas() {
+    const areas = await MapMgr.getInstance().fetchAreaMap('MapTower');
+    for (const [data, features] of Object.entries(areas)) {
+      const layers: L.GeoJSON[] = features.map((feature) => {
+        return L.geoJSON(feature, {
+          style: function(_) {
+            return { weight: 0.5, fill: false, color: '#60B0E0' }
+          },
+        });
+      });
+      layers.forEach(layer => this.refGrid[3].addLayer(layer));
+    }
+    this.showReferenceGridInternal();
+  }
+
+
+  async showReferenceGridInternal() {
+    if (!this.refGrid.length) {
+      this.refGrid = this.createMarkers();
+    }
+    const zoomLevel = this.m.getZoom();
+    let minZoom = [1, 4, 5, 1];
+    if (this.refGridOn) {
+      this.refGrid.forEach((layer, i) => {
+        //for (let i = 0; i < 4; i++) {
+        let visible = this.m.hasLayer(layer);
+        if (zoomLevel >= minZoom[i]) {
+          if (!visible) {
+            this.m.addLayer(layer);
+          }
+        } else {
+          if (visible) {
+            this.m.removeLayer(layer);
+          }
+        }
+      });
+    } else {
+      this.refGrid.forEach(layer => this.m.removeLayer(layer));
+    }
+
+  }
+  showReferenceGrid(show: boolean) {
+    this.refGridOn = show;
+    this.showReferenceGridInternal();
+  }
+
 
   toXYZ(latlng: L.LatLng): Point {
     return [latlng.lng, 0, latlng.lat];
@@ -151,10 +209,53 @@ export class MapBase {
       maxNativeZoom: 7,
     });
     baseLayer.addTo(this.m);
+    this.baseLayer = baseLayer;
 
     this.m.createPane('front').style.zIndex = '1000';
     this.m.createPane('front2').style.zIndex = '1001';
+
+    this.refGridOn = false;
+    this.m.on("zoom", () => {
+      this.showReferenceGridInternal();
+    });
   }
+  svgIconBase(width: number) {
+    return L.divIcon({
+      html: `<svg  viewBox="0 0 100 100" version="1.1"
+preserveAspectRatio="none"  xmlns="http://www.w3.org/2000/svg" >
+<path d="M 100 50 L 0 50 M 50 0 L 50 100" stroke="#60B0E0" stroke-width="${width}" />
+</svg>`,
+      className: "",
+      iconSize: [10, 10],
+      iconAnchor: [5, 5],
+    });
+  }
+  createMarkers() {
+    const svgIcon = this.svgIconBase(3);
+    const svgIcon2 = this.svgIconBase(6);
+    const svgIcon3 = this.svgIconBase(12);
+    let size = 125;
+    let markers = [L.layerGroup(), L.layerGroup(), L.layerGroup(), L.layerGroup()];
+    for (let i = 0; i < 20 * 4; i++) {
+      for (let j = 0; j < 16 * 4; j++) {
+        let z = -4000 + j * size + 125 / 2;
+        let x = -5000 + i * size + 125 / 2;
+        let k = 2;
+        let icon = svgIcon;
+        if (i % 4 == 0 && j % 4 == 0) {
+          icon = svgIcon3;
+          k = 0;
+        } else if (i % 4 == 0 || j % 4 == 0) {
+          icon = svgIcon2;
+          k = 1;
+        }
+        markers[k].addLayer(L.marker([z, x], { icon }));//.addTo(this.map.m);
+      }
+    }
+    this.loadTowerAreas();
+    return markers;
+  }
+
 
   private setZoomProp(zoom: number) {
     this.zoom = zoom;

--- a/src/MapBase.ts
+++ b/src/MapBase.ts
@@ -37,6 +37,7 @@ export class MapBase {
       this.m.removeLayer(this.baseLayer);
     }
   }
+
   async loadTowerAreas() {
     const areas = await MapMgr.getInstance().fetchAreaMap('MapTower');
     for (const [data, features] of Object.entries(areas)) {
@@ -51,7 +52,6 @@ export class MapBase {
     }
     this.showReferenceGridInternal();
   }
-
 
   async showReferenceGridInternal() {
     if (!this.refGrid.length) {
@@ -76,8 +76,8 @@ export class MapBase {
     } else {
       this.refGrid.forEach(layer => this.m.removeLayer(layer));
     }
-
   }
+
   showReferenceGrid(show: boolean) {
     this.refGridOn = show;
     this.showReferenceGridInternal();
@@ -249,13 +249,12 @@ preserveAspectRatio="none"  xmlns="http://www.w3.org/2000/svg" >
           icon = svgIcon2;
           k = 1;
         }
-        markers[k].addLayer(L.marker([z, x], { icon }));//.addTo(this.map.m);
+        markers[k].addLayer(L.marker([z, x], { icon }));
       }
     }
     this.loadTowerAreas();
     return markers;
   }
-
 
   private setZoomProp(zoom: number) {
     this.zoom = zoom;

--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -279,6 +279,9 @@ export default class AppMap extends mixins(MixinUtil) {
   private mapCastleAreas = new ui.Unobservable(L.layerGroup());
   showCastleAreas = false;
 
+  showBaseMap = true;
+  showReferenceGrid = false;
+
   private tempObjMarker: ui.Unobservable<MapMarker> | null = null;
 
   private settings: Settings | null = null;
@@ -1278,6 +1281,17 @@ export default class AppMap extends mixins(MixinUtil) {
         }
         this.mapSafeAreas.data.addTo(this.map.m);
       }
+    });
+  }
+
+  onShowBaseMap() {
+    this.$nextTick(() => {
+      this.map.showBaseMap(this.showBaseMap);
+    });
+  }
+  onShowReferenceGrid() {
+    this.$nextTick(() => {
+      this.map.showReferenceGrid(this.showReferenceGrid);
     });
   }
 

--- a/src/components/AppMap.vue
+++ b/src/components/AppMap.vue
@@ -241,6 +241,8 @@
         <b-checkbox switch v-model="showSafeAreas" @change="onShowSafeAreas">Enemy Non-Search Areas (Safe Zones)</b-checkbox>
         <b-checkbox switch v-model="showMapUnitGrid" @change="onShowMapUnitGridChanged">Show map unit grid</b-checkbox>
         <b-checkbox switch v-model="showCastleAreas" @change="onShowCastleAreas">Show Hyrule Castle Interior</b-checkbox>
+        <b-checkbox switch v-model="showBaseMap" @change="onShowBaseMap">Show Base Map</b-checkbox>
+        <b-checkbox switch v-model="showReferenceGrid" @change="onShowReferenceGrid">Show Map Reference Grid</b-checkbox>
         <hr/>
         <h4 class="subsection-heading">Item Auto Placement</h4>
         <b-radio-group stacked class="mb-4" v-model="shownAutoItem" @change="onShownAutoItemChanged">

--- a/src/components/AppMap.vue
+++ b/src/components/AppMap.vue
@@ -238,11 +238,15 @@
             <b-btn size="sm" variant="primary" @click="updateAreaMapVisibility()"><i class="fa fa-filter"></i></b-btn>
           </div>
         </b-form-group>
-        <b-checkbox switch v-model="showSafeAreas" @change="onShowSafeAreas">Enemy Non-Search Areas (Safe Zones)</b-checkbox>
+        <b-checkbox switch v-model="showSafeAreas" @change="onShowSafeAreas">Enemy non-search areas (safe zones)</b-checkbox>
         <b-checkbox switch v-model="showMapUnitGrid" @change="onShowMapUnitGridChanged">Show map unit grid</b-checkbox>
-        <b-checkbox switch v-model="showCastleAreas" @change="onShowCastleAreas">Show Hyrule Castle Interior</b-checkbox>
-        <b-checkbox switch v-model="showBaseMap" @change="onShowBaseMap">Show Base Map</b-checkbox>
-        <b-checkbox switch v-model="showReferenceGrid" @change="onShowReferenceGrid">Show Map Reference Grid</b-checkbox>
+        <b-checkbox switch v-model="showCastleAreas" @change="onShowCastleAreas">Show Hyrule castle interior</b-checkbox>
+        <b-checkbox switch v-model="showBaseMap" @change="onShowBaseMap">Show base map</b-checkbox>
+        <b-checkbox switch v-model="showReferenceGrid" @change="onShowReferenceGrid">
+          <div title="Display an overlap map with region outlines and grid markers, similar to that before Tower activation. This map can be displayed over the base map.">
+            Show region outlines and grid
+          </div>
+        </b-checkbox>
         <hr/>
         <h4 class="subsection-heading">Item Auto Placement</h4>
         <b-radio-group stacked class="mb-4" v-model="shownAutoItem" @change="onShownAutoItemChanged">


### PR DESCRIPTION
Add Reference Grid based on the undiscovered map section.

- Grid is 500m x 500m (large) and 125m x 125m (small)
- Smaller Grid is shown base on Zoom level
- Tower Areas outlines are included
- Leaflet layers are created once, on-demand
- Grid is offset by 125m/2 from the top and left
- Modifies `src/MapBase.ts` to control the base map layers

Thanks to Piston for this request.

Screen shots of the UI and map views below.

![Screenshot 2023-03-13 at 19-44-58 BotW Object Map](https://user-images.githubusercontent.com/126514/224856461-e4da8f5f-dd5b-4d5a-8c67-026281cd7ab3.png)
![Screenshot 2023-03-13 at 19-44-51 BotW Object Map](https://user-images.githubusercontent.com/126514/224856469-80c2700a-f42a-4ace-af3a-8a61552703d6.png)
![Screenshot 2023-03-13 at 19-48-45 BotW Object Map](https://user-images.githubusercontent.com/126514/224856771-8f05a7ca-ef23-44c7-907f-25030b1f4a20.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/objmap/117)
<!-- Reviewable:end -->
